### PR TITLE
feat: 홈 화면 및 회의 생성 화면 등 화면 선택 방식 변경

### DIFF
--- a/app/src/main/java/com/imhungry/jjongseol/ui/home/Calendar.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/home/Calendar.kt
@@ -1,4 +1,4 @@
-package com.imhungry.jjongseol.ui.component
+package com.imhungry.jjongseol.ui.home
 
 import android.os.Build
 import android.widget.NumberPicker
@@ -15,10 +15,13 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.TabRowDefaults.Divider
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -36,16 +39,59 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.navigation.NavController
 import com.imhungry.jjongseol.R
+import com.imhungry.jjongseol.ui.home.meetingdata.ScheduleItem
+import com.imhungry.jjongseol.ui.theme.md_theme_button_color_blue
 import java.time.LocalDate
 import java.time.YearMonth
+import java.time.format.DateTimeFormatter
+
+val schedules = listOf(
+    ScheduleItem("회의 1", "13:00", "2025.04.26"),
+    ScheduleItem("회의 2", "15:00", "2025.04.26"),
+    ScheduleItem("회의 1", "13:00", "2025.04.26"),
+    ScheduleItem("회의 2", "15:00", "2025.04.26"),
+    ScheduleItem("회의 1", "13:00", "2025.04.26"),
+    ScheduleItem("회의 2", "15:00", "2025.04.26"),
+    ScheduleItem("회의 1", "13:00", "2025.04.26"),
+    ScheduleItem("회의 2", "15:00", "2025.04.26"),
+    ScheduleItem("회의 1", "13:00", "2025.04.26"),
+    ScheduleItem("회의 2", "15:00", "2025.04.26"),
+    ScheduleItem("워크샵", "11:00", "2025.04.26"),
+    ScheduleItem("고객 미팅", "14:00", "2025.04.27"),
+    ScheduleItem("프로젝트 리뷰", "16:00", "2025.06.28"),
+    ScheduleItem("웹 세미나", "10:00", "2025.07.01"),
+    ScheduleItem("팀 런치", "12:00", "2025.07.01"),
+    ScheduleItem("제품 발표회", "15:00", "2025.07.02"),
+    ScheduleItem("경영진 회의", "09:00", "2025.07.03"),
+    ScheduleItem("기술 트레이닝", "13:30", "2025.07.03"),
+    ScheduleItem("마케팅 전략 논의", "11:00", "2025.07.04"),
+    ScheduleItem("영업 팀 회의", "15:00", "2025.07.04"),
+    ScheduleItem("개발자 컨퍼런스", "10:00", "2025.07.05"),
+    ScheduleItem("재무 검토 회의", "14:00", "2025.07.05")
+)
 
 @Composable
-fun CalendarScreen() {
+fun CalendarScreen(navController: NavController) {
     var currentYearMonth by remember { mutableStateOf(YearMonth.now()) }
     var selectedDate by remember { mutableStateOf(LocalDate.now()) }
     var showNumberPicker by remember { mutableStateOf(false) }
-
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(5.dp),
+        horizontalArrangement = Arrangement.End,
+    ) {
+        Text(
+            text = "오늘", color = md_theme_button_color_blue, modifier = Modifier
+                .padding(end = 5.dp)
+                .clickable {
+                    currentYearMonth = YearMonth.now()
+                    selectedDate = LocalDate.now()
+                }
+        )
+    }
     Column(modifier = Modifier
         .fillMaxSize()
         .padding(horizontal = 36.dp)) {
@@ -58,7 +104,8 @@ fun CalendarScreen() {
         CalendarGrid(
             yearMonth = currentYearMonth,
             selectedDate = selectedDate,
-            onDateSelected = { selectedDate = it }
+            onDateSelected = { selectedDate = it },
+            schedules = schedules
         )
     }
 
@@ -76,6 +123,20 @@ fun CalendarScreen() {
 
         )
     }
+
+    Divider(
+        color = Color.Gray,
+        thickness = 1.dp,
+        modifier = Modifier.padding(top = 30.dp,bottom = 10.dp)
+    )
+
+    val handleScheduleClick = { schedule: ScheduleItem ->
+        //navController.navigate("completeProfile")
+    }
+
+    DailyScheduleView(selectedDate.format(DateTimeFormatter.ofPattern("yyyy.MM.dd")),
+        schedules, handleScheduleClick)
+
 }
 
 @Composable
@@ -91,18 +152,6 @@ fun CalendarHeader(
             .padding(start = 4.dp, top = 16.dp, bottom = 16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Image(
-            painter = painterResource(R.drawable.prev),
-            contentDescription = "previous month",
-            modifier = Modifier
-                .size(24.dp)
-                .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null
-                ) {
-                    onPrev()
-                }
-        )
 
         Text(
             text = "${yearMonth.year}년 ${yearMonth.monthValue}월",
@@ -115,6 +164,19 @@ fun CalendarHeader(
                     indication = null
                 ) {
                     onTextClick()
+                }
+        )
+        Spacer(Modifier.weight(1f))
+        Image(
+            painter = painterResource(R.drawable.prev),
+            contentDescription = "previous month",
+            modifier = Modifier
+                .size(24.dp)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null
+                ) {
+                    onPrev()
                 }
         )
 
@@ -132,13 +194,13 @@ fun CalendarHeader(
         )
     }
 }
-
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun CalendarGrid(
     yearMonth: YearMonth,
     selectedDate: LocalDate,
-    onDateSelected: (LocalDate) -> Unit
+    onDateSelected: (LocalDate) -> Unit,
+    schedules: List<ScheduleItem>
 ) {
     val firstDayOfMonth = yearMonth.atDay(1)
     val daysInMonth = yearMonth.lengthOfMonth()
@@ -151,9 +213,18 @@ fun CalendarGrid(
         date
     }
 
+    val formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
+    val datesWithEvents = schedules
+        .filter { schedule ->
+            val scheduleDate = LocalDate.parse(schedule.date, formatter)
+            scheduleDate.month == yearMonth.month && scheduleDate.year == yearMonth.year
+        }
+        .map { LocalDate.parse(it.date, formatter) }
+        .toSet()
+
     Column {
         Row(Modifier.fillMaxWidth()) {
-            listOf("일", "월", "화", "수", "목", "금", "토").forEach {
+            listOf("SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT").forEach {
                 Text(
                     text = it,
                     modifier = Modifier.weight(1f),
@@ -172,6 +243,7 @@ fun CalendarGrid(
                     val isCurrentMonth = date.month == yearMonth.month
                     val isSelected = date == selectedDate
                     val dayOfWeek = date.dayOfWeek.value % 7
+                    val hasEvent = date in datesWithEvents
 
                     Box(
                         modifier = Modifier
@@ -180,7 +252,8 @@ fun CalendarGrid(
                             .padding(2.dp)
                             .background(
                                 when {
-                                    isSelected && isCurrentMonth -> Color(0xFFDAF2FF)
+                                    isSelected && isCurrentMonth && hasEvent -> Color(0xFFDAF2FF) //일정이 있고 선택된 날
+                                    isSelected && isCurrentMonth -> Color(0xFFDAF2FF) //선택된 날
                                     !isCurrentMonth -> Color.White.copy(alpha = 0.3f)
                                     else -> Color.Transparent
                                 },
@@ -198,9 +271,10 @@ fun CalendarGrid(
                             text = date.dayOfMonth.toString(),
                             style = MaterialTheme.typography.bodyMedium,
                             color = when {
-                                isSelected -> Color.Blue
-                                isCurrentMonth && dayOfWeek == 0 -> Color.Red
-                                isCurrentMonth -> Color.Black
+                                isSelected && hasEvent -> md_theme_button_color_blue //일정이 있고 선택된 날
+                                hasEvent -> md_theme_button_color_blue //일정만 있는 날
+                                isCurrentMonth && dayOfWeek == 0 -> Color.Red //일요일
+                                isCurrentMonth -> Color.Black //일반
                                 else -> Color.White
                             }
                         )
@@ -210,6 +284,8 @@ fun CalendarGrid(
         }
     }
 }
+
+
 
 @Composable
 fun NumberPickerDialog(
@@ -224,25 +300,18 @@ fun NumberPickerDialog(
         onDismissRequest = onDismiss,
         containerColor = Color.White,
         confirmButton = {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center
-            ) {
-                TextButton(onClick = {
-                    onConfirm(YearMonth.of(selectedYear, selectedMonth))
-                }) {
-                    Text(text = "취소", color = Color(0xFF1E93EF))
-                }
-                Spacer(modifier = Modifier.width(40.dp))
-                TextButton(onClick = {
-                    onConfirm(YearMonth.of(selectedYear, selectedMonth))
-                }) {
-                    Text(text = "확인", color = Color(0xFF1E93EF))
-                }
+            TextButton(onClick = {
+                onConfirm(YearMonth.of(selectedYear, selectedMonth))
+            }) {
+                Text(text = "확인", color = Color(0xFF1E93EF))
             }
         },
-        dismissButton = {},
+        dismissButton = {
+            TextButton(onClick = {
+                onConfirm(YearMonth.of(selectedYear, selectedMonth))
+            }) {
+                Text(text = "취소", color = Color(0xFF1E93EF))
+            }},
         text = {
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
                 AndroidView(
@@ -274,3 +343,39 @@ fun NumberPickerDialog(
     )
 }
 
+
+@Composable
+fun DailyScheduleView(selectedDate: String, schedules: List<ScheduleItem>, onScheduleClick: (ScheduleItem) -> Unit) {
+    val dailySchedules = schedules.filter { it.date == selectedDate }
+
+    if (dailySchedules.isEmpty()) {
+        Text("일정이 없습니다", modifier = Modifier.fillMaxWidth().widthIn(100.dp).padding(top=20.dp), textAlign = TextAlign.Center)
+    } else {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color(0xEDF3E7))
+                .padding(16.dp)
+        ) {
+            Text("일정 기록", style = androidx.compose.material.MaterialTheme.typography.h6)
+            Spacer(Modifier.height(20.dp))
+            dailySchedules.forEach { schedule ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(vertical = 4.dp)
+                            .clickable { onScheduleClick(schedule) },
+                ) {
+                    Text(
+                        text = schedule.title,
+                        style = androidx.compose.material.MaterialTheme.typography.body1
+                    )
+                    Spacer(Modifier.weight(1f))
+                    Text(
+                        text = schedule.time,
+                        style = androidx.compose.material.MaterialTheme.typography.body1
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/imhungry/jjongseol/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/home/HomeScreen.kt
@@ -153,6 +153,7 @@ fun HomeScreen(navController: NavController) {
 
 @Composable
 fun MainHomeScreen(navController: NavController){
+    var calendarToggle by remember { mutableStateOf(true) }
     ConstraintLayout (modifier = Modifier
         .background(Color.White)
         .fillMaxSize()){
@@ -160,7 +161,7 @@ fun MainHomeScreen(navController: NavController){
 
         LazyColumn(
             modifier = Modifier
-                .padding(30.dp)
+                .padding(top = 30.dp, start = 30.dp, bottom = 100.dp, end = 30.dp)
                 .fillMaxSize()
                 .constrainAs(scrollList) {
                     top.linkTo(parent.top)
@@ -172,23 +173,43 @@ fun MainHomeScreen(navController: NavController){
         ) {
             item {
                 Spacer(Modifier.height(60.dp))
+                Row(
+                    modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(5.dp),
+                    horizontalArrangement = Arrangement.End,
+                    ){
+                    Text(text = if(calendarToggle) "캘린더" else "리스트"
+                        ,color = md_theme_button_color_blue
+                        ,modifier = Modifier
+                            .padding(end = 5.dp)
+                            .clickable { calendarToggle = !calendarToggle })
+                }
                 Divider(
                     color = Color.Gray,
                     thickness = 1.dp,
                     modifier = Modifier.padding(vertical = 10.dp)
                 )
-                ScheduledMeetingScreen()
-                Canvas(modifier = Modifier
-                    .fillMaxWidth()
-                    .height(1.dp)) {
-                    drawLine(
-                        color = Color.Gray,
-                        start = Offset(0f, 0f),
-                        end = Offset(size.width, 0f),
-                        pathEffect = PathEffect.dashPathEffect(floatArrayOf(10f, 10f), 0f)
-                    )
+                if(calendarToggle) {
+                    ScheduledMeetingScreen()
+                    Canvas(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(1.dp)
+                    ) {
+                        drawLine(
+                            color = Color.Gray,
+                            start = Offset(0f, 0f),
+                            end = Offset(size.width, 0f),
+                            pathEffect = PathEffect.dashPathEffect(floatArrayOf(10f, 10f), 0f)
+                        )
+                    }
+                    MeetingRecordsScreen()
+
                 }
-                MeetingRecordsScreen()
+                else{
+                    CalendarScreen(navController)
+                }
             }
         }
 
@@ -302,3 +323,4 @@ fun MeetingCard() {
         }
     }
 }
+

--- a/app/src/main/java/com/imhungry/jjongseol/ui/home/MeetingRecord.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/home/MeetingRecord.kt
@@ -1,6 +1,7 @@
 package com.imhungry.jjongseol.ui.home
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
@@ -10,25 +11,56 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.unit.dp
+import com.imhungry.jjongseol.ui.home.meetingdata.MeetingRecord
 
 @Composable
 fun MeetingRecordsScreen() {
     var showDetails by remember { mutableStateOf(false) }
-    val meetingRecords = listOf(
-        "회의 1 - 2022.1.2",
-        "회의 2 - 2022.10.25",
-        "회의 3 - 2022.11.20",
-        "회의 4 - 2022.12.27",
-        "회의 5 - 2023.1.2",
-        "회의 6 - 2024.10.6"
+    var pagingIndex by remember { mutableStateOf(10) }
+    val meetingRecordList = listOf(
+        MeetingRecord("회의 1", "2025.1.2"),
+        MeetingRecord("회의 2", "2025.1.2"),
+        MeetingRecord("회의 3", "2026.1.2"),
+        MeetingRecord("회의 4", "2026.1.2"),
+        MeetingRecord("회의 1", "2022.1.2"),
+        MeetingRecord("회의 2", "2022.10.25"),
+        MeetingRecord("회의 3", "2022.11.20"),
+        MeetingRecord("회의 4", "2022.12.27"),
+        MeetingRecord("회의 5", "2023.1.2"),
+        MeetingRecord("회의 6", "2024.10.6"),
+        MeetingRecord("회의 1", "2022.1.2"),
+        MeetingRecord("회의 2", "2022.10.25"),
+        MeetingRecord("회의 3", "2022.11.20"),
+        MeetingRecord("회의 4", "2022.12.27"),
+        MeetingRecord("회의 5", "2023.1.2"),
+        MeetingRecord("회의 6", "2024.10.6"),
+        MeetingRecord("회의 1", "2025.1.2"),
+        MeetingRecord("회의 2", "2025.1.2"),
+        MeetingRecord("회의 3", "2026.1.2"),
+        MeetingRecord("회의 4", "2026.1.2"),
+        MeetingRecord("회의 1", "2022.1.2"),
+        MeetingRecord("회의 2", "2022.10.25"),
+        MeetingRecord("회의 3", "2022.11.20"),
+        MeetingRecord("회의 4", "2022.12.27"),
+        MeetingRecord("회의 5", "2023.1.2"),
+        MeetingRecord("회의 6", "2024.10.6"),
+        MeetingRecord("회의 1", "2022.1.2"),
+        MeetingRecord("회의 2", "2022.10.25"),
+        MeetingRecord("회의 3", "2022.11.20"),
+        MeetingRecord("회의 4", "2022.12.27"),
+        MeetingRecord("회의 5", "2023.1.2"),
+        MeetingRecord("회의 6", "2024.10.6")
     )
 
     Column(
         modifier = Modifier
             .padding(16.dp)
-            .fillMaxWidth(),
+            .fillMaxWidth()
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null
+            ) { showDetails = !showDetails },
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Row(
@@ -44,7 +76,6 @@ fun MeetingRecordsScreen() {
                 imageVector = Icons.Filled.ArrowDropDown,
                 contentDescription = "토글 버튼",
                 modifier = Modifier
-                    .clickable { showDetails = !showDetails }
                     .size(30.dp)
                     .graphicsLayer {
                         rotationZ = if (showDetails) 0f else 270f
@@ -52,21 +83,42 @@ fun MeetingRecordsScreen() {
             )
         }
         if (showDetails) {
-            meetingRecords.forEach { record ->
+            val currentList = meetingRecordList.take(pagingIndex)
+            currentList.forEach { record ->
                 MeetingRecordButton(record)
+            }
+            if (pagingIndex < meetingRecordList.size) {
+                Text(
+                    text = "더보기",
+                    style = MaterialTheme.typography.bodyLarge.copy(color = Color.Gray),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp)
+                        .clickable {
+                            pagingIndex = (pagingIndex + 10).coerceAtMost(meetingRecordList.size)
+                        }
+                )
             }
         }
     }
 }
 
 @Composable
-fun MeetingRecordButton(record: String) {
-    Text(
-        text = buildAnnotatedString { append(record) },
-        style = MaterialTheme.typography.bodyLarge.copy(color = Color.Black),
+fun MeetingRecordButton(record: MeetingRecord) {
+    Row(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 8.dp)
-            .clickable { }
-    )
+            .clickable { },
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = record.title,
+            style = MaterialTheme.typography.bodyLarge
+        )
+        Text(
+            text = record.date,
+            style = MaterialTheme.typography.bodyLarge.copy(color = Color.Gray)
+        )
+    }
 }

--- a/app/src/main/java/com/imhungry/jjongseol/ui/home/ScheduledMeeting.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/home/ScheduledMeeting.kt
@@ -1,37 +1,91 @@
 package com.imhungry.jjongseol.ui.home
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
-import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import com.imhungry.jjongseol.ui.home.meetingdata.ScheduledMeeting
 
 @Composable
 fun ScheduledMeetingScreen() {
     var showDetails by remember { mutableStateOf(false) }
-    val meetingRecords = listOf(
-        "회의 1 - 2025.1.2",
-        "회의 2 - 2025.1.2",
-        "회의 3 - 2026.1.2",
-        "회의 4 - 2026.1.2",
+    var pagingIndex by remember { mutableStateOf(10) }
+    val scheduledMeetingList = listOf(
+        ScheduledMeeting("회의 1", "2025.1.2"),
+        ScheduledMeeting("회의 2", "2025.1.2"),
+        ScheduledMeeting("회의 3", "2026.1.2"),
+        ScheduledMeeting("회의 4", "2026.1.2"),
+        ScheduledMeeting("회의 1", "2022.1.2"),
+        ScheduledMeeting("회의 2", "2022.10.25"),
+        ScheduledMeeting("회의 3", "2022.11.20"),
+        ScheduledMeeting("회의 4", "2022.12.27"),
+        ScheduledMeeting("회의 5", "2023.1.2"),
+        ScheduledMeeting("회의 6", "2024.10.6"),
+        ScheduledMeeting("회의 1", "2022.1.2"),
+        ScheduledMeeting("회의 2", "2022.10.25"),
+        ScheduledMeeting("회의 3", "2022.11.20"),
+        ScheduledMeeting("회의 4", "2022.12.27"),
+        ScheduledMeeting("회의 1", "2025.1.2"),
+        ScheduledMeeting("회의 2", "2025.1.2"),
+        ScheduledMeeting("회의 3", "2026.1.2"),
+        ScheduledMeeting("회의 4", "2026.1.2"),
+        ScheduledMeeting("회의 1", "2022.1.2"),
+        ScheduledMeeting("회의 2", "2022.10.25"),
+        ScheduledMeeting("회의 3", "2022.11.20"),
+        ScheduledMeeting("회의 4", "2022.12.27"),
+        ScheduledMeeting("회의 5", "2023.1.2"),
+        ScheduledMeeting("회의 6", "2024.10.6"),
+        ScheduledMeeting("회의 1", "2022.1.2"),
+        ScheduledMeeting("회의 2", "2022.10.25"),
+        ScheduledMeeting("회의 3", "2022.11.20"),
+        ScheduledMeeting("회의 4", "2022.12.27"),
+        ScheduledMeeting("회의 1", "2025.1.2"),
+        ScheduledMeeting("회의 2", "2025.1.2"),
+        ScheduledMeeting("회의 3", "2026.1.2"),
+        ScheduledMeeting("회의 4", "2026.1.2"),
+        ScheduledMeeting("회의 1", "2022.1.2"),
+        ScheduledMeeting("회의 2", "2022.10.25"),
+        ScheduledMeeting("회의 3", "2022.11.20"),
+        ScheduledMeeting("회의 4", "2022.12.27"),
+        ScheduledMeeting("회의 5", "2023.1.2"),
+        ScheduledMeeting("회의 6", "2024.10.6"),
+        ScheduledMeeting("회의 1", "2022.1.2"),
+        ScheduledMeeting("회의 2", "2022.10.25"),
+        ScheduledMeeting("회의 3", "2022.11.20"),
+        ScheduledMeeting("회의 4", "2022.12.27"),
+        ScheduledMeeting("회의 1", "2025.1.2"),
+        ScheduledMeeting("회의 2", "2025.1.2"),
+        ScheduledMeeting("회의 3", "2026.1.2"),
+        ScheduledMeeting("회의 4", "2026.1.2"),
+        ScheduledMeeting("회의 1", "2022.1.2"),
+        ScheduledMeeting("회의 2", "2022.10.25"),
+        ScheduledMeeting("회의 3", "2022.11.20"),
+        ScheduledMeeting("회의 4", "2022.12.27"),
+        ScheduledMeeting("회의 5", "2023.1.2"),
+        ScheduledMeeting("회의 6", "2024.10.6"),
+        ScheduledMeeting("회의 1", "2022.1.2"),
+        ScheduledMeeting("회의 2", "2022.10.25"),
+        ScheduledMeeting("회의 3", "2022.11.20"),
+        ScheduledMeeting("회의 4", "2022.12.27"),
+
     )
 
     Column(
         modifier = Modifier
             .padding(16.dp)
-            .fillMaxWidth(),
+            .fillMaxWidth()
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null
+            ) { showDetails = !showDetails },
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Row(
@@ -47,7 +101,6 @@ fun ScheduledMeetingScreen() {
                 imageVector = Icons.Filled.ArrowDropDown,
                 contentDescription = "토글 버튼",
                 modifier = Modifier
-                    .clickable { showDetails = !showDetails }
                     .size(30.dp)
                     .graphicsLayer {
                         rotationZ = if (showDetails) 0f else 270f
@@ -55,21 +108,42 @@ fun ScheduledMeetingScreen() {
             )
         }
         if (showDetails) {
-            meetingRecords.forEach { record ->
+            val currentList = scheduledMeetingList.take(pagingIndex)
+            currentList.forEach { record ->
                 ScheduledMeetingButton(record)
+            }
+            if (pagingIndex < scheduledMeetingList.size) {
+                Text(
+                    text = "더보기",
+                    style = MaterialTheme.typography.bodyLarge.copy(color = Color.Gray),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp)
+                        .clickable {
+                            pagingIndex = (pagingIndex + 10).coerceAtMost(scheduledMeetingList.size)
+                        }
+                )
             }
         }
     }
 }
 
 @Composable
-fun ScheduledMeetingButton(record: String) {
-    Text(
-        text = buildAnnotatedString { append(record) },
-        style = MaterialTheme.typography.bodyLarge.copy(color = Color.Black),
+fun ScheduledMeetingButton(record: ScheduledMeeting) {
+    Row(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 8.dp)
-            .clickable { }
-    )
+            .clickable { },
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = record.title,
+            style = MaterialTheme.typography.bodyLarge
+        )
+        Text(
+            text = record.date,
+            style = MaterialTheme.typography.bodyLarge.copy(color = Color.Gray)
+        )
+    }
 }

--- a/app/src/main/java/com/imhungry/jjongseol/ui/home/meetingdata/MeetingRecord.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/home/meetingdata/MeetingRecord.kt
@@ -1,0 +1,3 @@
+package com.imhungry.jjongseol.ui.home.meetingdata
+
+data class MeetingRecord(val title: String, val date: String)

--- a/app/src/main/java/com/imhungry/jjongseol/ui/home/meetingdata/ScheduleItem.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/home/meetingdata/ScheduleItem.kt
@@ -1,0 +1,3 @@
+package com.imhungry.jjongseol.ui.home.meetingdata
+
+data class ScheduleItem(val title: String, val time: String, val date: String)

--- a/app/src/main/java/com/imhungry/jjongseol/ui/home/meetingdata/ScheduledMeeting.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/home/meetingdata/ScheduledMeeting.kt
@@ -1,0 +1,3 @@
+package com.imhungry.jjongseol.ui.home.meetingdata
+
+data class ScheduledMeeting (val title: String, val date: String)

--- a/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/CreateNewMeeting.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/CreateNewMeeting.kt
@@ -4,9 +4,13 @@ import SearchScreen
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -16,12 +20,17 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Icon
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -29,14 +38,21 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import androidx.navigation.NavController
+import com.imhungry.jjongseol.ui.home.CalendarGrid
+import com.imhungry.jjongseol.ui.home.CalendarScreen
+import com.imhungry.jjongseol.ui.home.DataPickerCalendar
+import com.imhungry.jjongseol.ui.home.schedules
 import com.imhungry.jjongseol.ui.newmeeting.agenda.AgendaListScreen
 import com.imhungry.jjongseol.ui.newmeeting.breaktime.BreakTimeRow
-import com.imhungry.jjongseol.ui.newmeeting.dateandtime.DatePickerField
 import com.imhungry.jjongseol.ui.newmeeting.dateandtime.TimeDurationPicker
 import com.imhungry.jjongseol.ui.theme.md_theme_button_color_blue
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.format.DateTimeFormatter
 
 @Composable
 fun CreateNewMeetingScreen(navController: NavController){
@@ -44,6 +60,11 @@ fun CreateNewMeetingScreen(navController: NavController){
     val leaderName = remember { mutableStateOf("") }
     //val memberLists = remember { mutableStateOf("") }
     val place = remember { mutableStateOf("") }
+
+    var currentYearMonth by remember { mutableStateOf(YearMonth.now()) }
+    var selectedDate: LocalDate? by remember { mutableStateOf(null) }
+    var dateText by remember { mutableStateOf(LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd"))) }
+    var showCalendarDialog by remember { mutableStateOf(false) }
 
     ConstraintLayout (modifier = Modifier
         .background(Color.White)
@@ -201,8 +222,37 @@ fun CreateNewMeetingScreen(navController: NavController){
                         )
                     )
                 }
-                DatePickerField()
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp)
+                        .height(55.dp)
+                        .background(Color.White, RoundedCornerShape(15.dp))
+                        .border(1.dp, Color.Gray, RoundedCornerShape(15.dp))
+                        .clickable(
+                            onClick = { showCalendarDialog = true },
+                            indication = null,
+                            interactionSource = remember { MutableInteractionSource() }
+                        ),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = dateText,
+                        style = TextStyle(fontSize = 16.sp, color = Color.Black),
+                        modifier = Modifier.padding(start = 20.dp, top = 10.dp, bottom = 10.dp)
+                    )
+                    Spacer(Modifier.weight(1f))
+                    Icon(
+                        imageVector = Icons.Filled.DateRange,
+                        contentDescription = "회의 날짜 선택",
+                        modifier = Modifier.padding(end = 10.dp)
+                    )
+                }
             }
+
+
 
             item {
                 Box(
@@ -325,10 +375,24 @@ fun CreateNewMeetingScreen(navController: NavController){
                 }
             }
 
-
-
         }
 
+        if (showCalendarDialog) {
+            Dialog(onDismissRequest = { showCalendarDialog = false }) {
+                val defaultSelected = selectedDate ?: LocalDate.now()
+                DataPickerCalendar(
+                    navController = navController,
+                    initialSelectedDate = defaultSelected,
+                    onDateSelected = { date, isConfirmed ->
+                        if (isConfirmed) {
+                            selectedDate = date
+                            dateText = date.format(DateTimeFormatter.ofPattern("yyyy/MM/dd"))
+                        }
+                        showCalendarDialog = false
+                    }
+                )
+            }
+        }
 
         Box(
             contentAlignment = Alignment.TopStart,

--- a/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/dateandtime/DataPickerCalendar.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/dateandtime/DataPickerCalendar.kt
@@ -1,0 +1,73 @@
+package com.imhungry.jjongseol.ui.home
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import java.time.LocalDate
+import java.time.YearMonth
+
+@Composable
+fun DataPickerCalendar(navController: NavController, initialSelectedDate: LocalDate, onDateSelected: (LocalDate, Boolean) -> Unit) {
+    var currentYearMonth by remember { mutableStateOf(YearMonth.from(initialSelectedDate)) }
+    var selectedDate by remember { mutableStateOf(initialSelectedDate) }
+    var showNumberPicker by remember { mutableStateOf(false) }
+
+    Surface(
+        modifier = Modifier.height(400.dp).width(500.dp),
+        color = Color.White,
+        shape = MaterialTheme.shapes.medium
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            CalendarHeader(
+                yearMonth = currentYearMonth,
+                onPrev = { currentYearMonth = currentYearMonth.minusMonths(1) },
+                onNext = { currentYearMonth = currentYearMonth.plusMonths(1) },
+                onTextClick = { showNumberPicker = !showNumberPicker }
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            if (!showNumberPicker) {
+                CalendarGrid(
+                    yearMonth = currentYearMonth,
+                    selectedDate = selectedDate,
+                    onDateSelected = { selectedDate = it },
+                    schedules = listOf()
+                )
+            } else {
+                NumberPickerDialog(
+                    initialYearMonth = currentYearMonth,
+                    onDismiss = { showNumberPicker = false },
+                    onConfirm = {
+                        currentYearMonth = it
+                        val newDay = selectedDate.dayOfMonth
+                        val maxDay = it.lengthOfMonth()
+                        selectedDate = it.atDay(minOf(newDay, maxDay))
+                        showNumberPicker = false
+                    }
+                )
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                TextButton(onClick = { onDateSelected(selectedDate, false) }) {
+                    Text("취소")
+                }
+                TextButton(onClick = { onDateSelected(selectedDate, true) }) {
+                    Text("확인")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/dateandtime/DateSettingScreen.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/dateandtime/DateSettingScreen.kt
@@ -1,22 +1,28 @@
 package com.imhungry.jjongseol.ui.newmeeting.dateandtime
 
-import android.app.DatePickerDialog
+import android.widget.NumberPicker
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.AlertDialog
 import androidx.compose.material.Icon
+import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -24,56 +30,110 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import java.util.Calendar
+import androidx.compose.ui.viewinterop.AndroidView
+import com.imhungry.jjongseol.ui.theme.md_theme_button_color_blue
+import java.time.LocalDate
+import java.time.YearMonth
 
 @Composable
-fun DatePickerField() {
+fun DatePickerDialog() {
     val context = LocalContext.current
-    val calendar = remember { Calendar.getInstance() }
-    val year = calendar.get(Calendar.YEAR)
-    val month = calendar.get(Calendar.MONTH)
-    val day = calendar.get(Calendar.DAY_OF_MONTH)
+    val initialYearMonthDay = remember { LocalDate.now() }
+    var selectedYear by remember { mutableStateOf(initialYearMonthDay.year) }
+    var selectedMonth by remember { mutableStateOf(initialYearMonthDay.monthValue) }
+    var selectedDay by remember { mutableStateOf(initialYearMonthDay.dayOfMonth) }
+    var daysInMonth = remember(selectedYear, selectedMonth) {
+        YearMonth.of(selectedYear, selectedMonth).lengthOfMonth()
+    }
 
+    val showDatePickerDialog = remember { mutableStateOf(false) }
     val dateText = remember { mutableStateOf("YYYY / MM / DD") }
-    val textColor = if (dateText.value == "YYYY / MM / DD") Color.LightGray else Color.Black
 
-    val datePickerDialog = DatePickerDialog(
-        context,
-        { _, selectedYear, selectedMonth, selectedDay ->
-            dateText.value = "${selectedYear} / ${selectedMonth + 1} / $selectedDay"
-        }, year, month, day
-    )
-
-    Box(
+    Row(
         modifier = Modifier
             .fillMaxWidth()
-            .height(70.dp)
             .padding(8.dp)
+            .height(55.dp)
             .border(1.dp, Color.Gray, RoundedCornerShape(15.dp))
-            .clickable {
-                datePickerDialog.show()
-            },
-        contentAlignment = Alignment.CenterStart
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null
+            ) { showDatePickerDialog.value = true },
+        horizontalArrangement  = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = dateText.value,
-                style = TextStyle(
-                    color = textColor,
-                    fontSize = 16.sp
-                ),
-                modifier = Modifier.padding(start = 5.dp)
-            )
-            Spacer(Modifier.weight(1f))
-            Icon(
-                imageVector = Icons.Filled.DateRange,
-                contentDescription = "회의 날짜",
-                modifier = Modifier.align(Alignment.CenterVertically)
-            )
-        }
+        Text(
+            text = dateText.value,
+            style = TextStyle(fontSize = 16.sp, color = Color.Black),
+            modifier = Modifier.padding(start = 20.dp, top = 10.dp, bottom = 10.dp)
+        )
+        Spacer(Modifier.weight(1f))
+
+        Icon(
+            imageVector = Icons.Filled.DateRange,
+            contentDescription = "회의 날짜 선택",
+            modifier = Modifier.padding(end = 10.dp)
+        )
+    }
+
+    if (showDatePickerDialog.value) {
+        AlertDialog(
+            onDismissRequest = { showDatePickerDialog.value = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    dateText.value = "$selectedYear / $selectedMonth / $selectedDay"
+                    showDatePickerDialog.value = false
+                }) {
+                    Text(text = "확인", color = md_theme_button_color_blue,
+                        modifier = Modifier.padding(10.dp))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDatePickerDialog.value = false }) {
+                    Text(text = "취소", color = md_theme_button_color_blue,
+                        modifier = Modifier.padding(10.dp))
+                }
+            },
+            text = {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceEvenly
+                ) {
+                    NumberPickerComponent("", 1900, 2125, selectedYear) { newVal ->
+                        selectedYear = newVal
+                        daysInMonth = YearMonth.of(selectedYear, selectedMonth).lengthOfMonth()
+                        selectedDay = minOf(selectedDay, daysInMonth)
+                    }
+                    NumberPickerComponent("", 1, 12, selectedMonth) { newVal ->
+                        selectedMonth = newVal
+                        daysInMonth = YearMonth.of(selectedYear, selectedMonth).lengthOfMonth()
+                        selectedDay = minOf(selectedDay, daysInMonth)
+                    }
+                    NumberPickerComponent("", 1, daysInMonth, selectedDay) { newVal ->
+                        selectedDay = newVal
+                    }
+                }
+            }
+        )
     }
 }
 
+@Composable
+fun NumberPickerComponent(label: String, min: Int, max: Int, value: Int, onValueChange: (Int) -> Unit) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(text = label)
+        AndroidView(
+            factory = { context ->
+                NumberPicker(context).apply {
+                    minValue = min
+                    maxValue = max
+                    setValue(value)
+                    setOnValueChangedListener { _, _, newVal ->
+                        onValueChange(newVal)
+                    }
+                }
+            },
+            update = { it.maxValue = max; it.minValue = min; it.value = value }
+        )
+    }
+}

--- a/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/dateandtime/TimeSettingScreen.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/dateandtime/TimeSettingScreen.kt
@@ -1,176 +1,255 @@
 package com.imhungry.jjongseol.ui.newmeeting.dateandtime
 
-import android.app.TimePickerDialog
+import android.widget.NumberPicker
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
-import androidx.compose.material.OutlinedTextField
-import androidx.compose.material.TextFieldDefaults
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.material.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import java.util.Calendar
-
+import androidx.compose.ui.viewinterop.AndroidView
+import java.util.*
 
 @Composable
 fun TimeDurationPicker() {
-    val context = LocalContext.current
     var startTime by remember { mutableStateOf("HH:MM") }
     var endTime by remember { mutableStateOf("HH:MM") }
     var durationInMinutes by remember { mutableStateOf("") }
-
-    fun calculateEndTime(start: String, duration: Int) {
-        val (hour, minute) = start.split(":").map { it.toInt() }
-        val calendar = Calendar.getInstance().apply {
-            set(Calendar.HOUR_OF_DAY, hour)
-            set(Calendar.MINUTE, minute)
-            add(Calendar.MINUTE, duration)
-        }
-        endTime = String.format("%02d:%02d", calendar.get(Calendar.HOUR_OF_DAY), calendar.get(
-            Calendar.MINUTE))
-    }
-
-    fun calculateDuration(startTime: String, endTime: String) {
-        if (startTime.isNotEmpty() && endTime.isNotEmpty()) {
-            val start = Calendar.getInstance().apply {
-                val (startHour, startMinute) = startTime.split(":").map { it.toInt() }
-                set(Calendar.HOUR_OF_DAY, startHour)
-                set(Calendar.MINUTE, startMinute)
-            }
-            val end = Calendar.getInstance().apply {
-                val (endHour, endMinute) = endTime.split(":").map { it.toInt() }
-                set(Calendar.HOUR_OF_DAY, endHour)
-                set(Calendar.MINUTE, endMinute)
-            }
-            if (end.before(start)) {
-                end.add(Calendar.DATE, 1)
-            }
-            val duration = (end.timeInMillis - start.timeInMillis) / (60 * 1000)
-            durationInMinutes = duration.toString()
-        }
-    }
-
-    fun pickTime(isStartTime: Boolean, updateTime: (String) -> Unit) {
-        val timeSetListener = TimePickerDialog.OnTimeSetListener { _, hour, minute ->
-            val formattedTime = String.format("%02d:%02d", hour, minute)
-            updateTime(formattedTime)
-            if (isStartTime) {
-                startTime = formattedTime
-            } else {
-                endTime = formattedTime
-            }
-            if (startTime.isNotEmpty() && endTime.isNotEmpty() && startTime != "HH:MM" && endTime != "HH:MM") {
-                calculateDuration(startTime, endTime)
-            }
-        }
-
-        val currentTime = Calendar.getInstance()
-        val (hour, minute) = when {
-            isStartTime && startTime.matches(Regex("\\d{2}:\\d{2}")) -> startTime.split(":").map { it.toInt() }
-            !isStartTime && endTime.matches(Regex("\\d{2}:\\d{2}")) -> endTime.split(":").map { it.toInt() }
-            else -> listOf(currentTime.get(Calendar.HOUR_OF_DAY), currentTime.get(Calendar.MINUTE))
-        }
-
-        TimePickerDialog(context, timeSetListener, hour, minute, true).show()
-    }
+    var showStartTimePicker by remember { mutableStateOf(false) }
+    var showEndTimePicker by remember { mutableStateOf(false) }
 
     Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(8.dp),
+        modifier = Modifier.fillMaxWidth().padding(8.dp),
         horizontalAlignment = Alignment.CenterHorizontally
-
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
-            Button(modifier = Modifier
-                .height(60.dp),
-                onClick = { pickTime(true, { startTime = it }) },
-                shape = RoundedCornerShape(15.dp),
-                colors = ButtonDefaults.buttonColors(
-                    backgroundColor = Color.White
-                ),
-                border = BorderStroke(1.dp, Color.Gray)
-            ) {
-                Text(text = startTime)
+            Box(modifier=Modifier.weight(10f)) {
+                TimePickerButton("시작 시간", startTime,Modifier ) {
+                    showStartTimePicker = true
+                }
             }
-            Spacer(Modifier.width(5.dp))
-            Text(" ~ ",
-                style = TextStyle(
-                    fontSize = 20.sp
-                )
-            )
-            Spacer(Modifier.width(5.dp))
-            Button(modifier = Modifier
-                .height(60.dp),
-                onClick = { pickTime(false, { endTime = it }) },
-                shape = RoundedCornerShape(15.dp),
-                colors = ButtonDefaults.buttonColors(
-                    backgroundColor = Color.White
-                ),
-                border = BorderStroke(1.dp, Color.Gray),
-            ) {
-                Text(text = endTime)
+            Spacer(Modifier.weight(1f))
+            Text("~", style = MaterialTheme.typography.h6)
+            Spacer(Modifier.weight(1f))
+            Box(modifier=Modifier.weight(10f)) {
+                TimePickerButton("종료 시간", endTime, Modifier) {
+                    showEndTimePicker = true
+                }
             }
-            Spacer(Modifier.width(10.dp))
+            Spacer(Modifier.weight(1f))
+            Row(verticalAlignment = Alignment.CenterVertically, modifier=Modifier.weight(10f)){
+                Box(modifier=Modifier.weight(4f)) {
+                    DurationInput(durationInMinutes, onDurationChange = { newValue ->
+                        durationInMinutes = newValue
+                        if (startTime != "HH:MM" && newValue.isNotEmpty()) {
+                            calculateEndTime(startTime, newValue.toInt()) { calculatedEndTime ->
+                                endTime = calculatedEndTime
+                            }
+                        }
+                    })
+                }
+                Spacer(Modifier.width(10.dp))
+                Text("분", style = TextStyle(fontSize = 15.sp), modifier=Modifier.weight(1f))
+            }
+        }
 
-            Spacer(Modifier.width(10.dp))
-            OutlinedTextField(
-                value = durationInMinutes,
-                onValueChange = { newValue ->
-                    val filtered = newValue.filter { it.isDigit() }
-                    if (filtered.isNotEmpty()) {
-                        val minutes = filtered.toInt()
-                        if (minutes <= 14400) {
-                            durationInMinutes = filtered
-                        } else {
-                            durationInMinutes = "14400"
+        if (showStartTimePicker) {
+            CustomTimePickerDialog(
+                initialTime = startTime,
+                onConfirm = { selectedTime ->
+                    startTime = selectedTime
+                    showStartTimePicker = false
+                    if (endTime != "HH:MM") {
+                        updateDurationFromTimes(startTime, endTime) {
+                            durationInMinutes = it.toString()
                         }
-                        if (startTime.matches(Regex("\\d{2}:\\d{2}"))) {
-                            calculateEndTime(startTime, durationInMinutes.toInt())
-                        }
-                    } else {
-                        durationInMinutes = ""
                     }
                 },
-                singleLine = true,
-                modifier = Modifier
-                    .width(80.dp)
-                    .height(60.dp)
-                    .border(1.dp, Color.Gray, RoundedCornerShape(15.dp)),
-                colors = TextFieldDefaults.outlinedTextFieldColors(
-                    textColor = Color.Black,
-                    cursorColor = Color.Black,
-                    backgroundColor = Color.White,
-                    focusedBorderColor = Color.Transparent,
-                    unfocusedBorderColor = Color.Transparent
-                )
-            )
-            Spacer(Modifier.width(10.dp))
-            Text("분",
-                style = TextStyle(
-                    fontSize = 15.sp
-                )
+                onDismiss = {
+                    showStartTimePicker = false
+                }
             )
         }
 
+        if (showEndTimePicker) {
+            CustomTimePickerDialog(
+                initialTime = endTime,
+                onConfirm = { selectedTime ->
+                    endTime = selectedTime
+                    showEndTimePicker = false
+                    if (startTime != "HH:MM") {
+                        updateDurationFromTimes(startTime, endTime) {
+                            durationInMinutes = it.toString()
+                        }
+                    }
+                },
+                onDismiss = {
+                    showEndTimePicker = false
+                }
+            )
+        }
+
+    }
+}
+
+fun calculateEndTime(start: String, duration: Int, onResult: (String) -> Unit) {
+    val (hour, minute) = start.split(":").map { it.toInt() }
+    val calendar = Calendar.getInstance().apply {
+        set(Calendar.HOUR_OF_DAY, hour)
+        set(Calendar.MINUTE, minute)
+        add(Calendar.MINUTE, duration)
+    }
+    onResult(String.format("%02d:%02d", calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE)))
+}
+
+fun updateDurationFromTimes(start: String, end: String, onResult: (Int) -> Unit) {
+    val startCalendar = Calendar.getInstance().apply {
+        val (hour, minute) = start.split(":").map { it.toInt() }
+        set(Calendar.HOUR_OF_DAY, hour)
+        set(Calendar.MINUTE, minute)
+    }
+
+    val endCalendar = Calendar.getInstance().apply {
+        val (hour, minute) = end.split(":").map { it.toInt() }
+        set(Calendar.HOUR_OF_DAY, hour)
+        set(Calendar.MINUTE, minute)
+    }
+
+    if (endCalendar.before(startCalendar)) {
+        endCalendar.add(Calendar.DATE, 1)  //다음 날로 설정하기
+    }
+
+    val duration = ((endCalendar.timeInMillis - startCalendar.timeInMillis) / 60000).toInt()
+    onResult(duration)
+}
+
+
+@Composable
+fun TimePickerButton(label: String, time: String, modifier: Modifier = Modifier, onClick: () -> Unit) {
+    Button(
+        onClick = onClick,
+        modifier = modifier
+            .height(60.dp)
+            .fillMaxWidth()
+            .widthIn(min = 100.dp),
+        shape = RoundedCornerShape(15.dp),
+        colors = ButtonDefaults.buttonColors(backgroundColor = Color.White),
+        border = BorderStroke(1.dp, Color.Gray)
+    ) {
+        Text(time, fontSize = 16.sp)
+    }
+}
+
+@Composable
+fun DurationInput(value: String, modifier: Modifier = Modifier, onDurationChange: (String) -> Unit) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = {
+            try {
+                var numericValue = it.toInt()
+                if (numericValue > 1440) {
+                    numericValue = 1440
+                }
+                onDurationChange(numericValue.toString())
+            } catch (e: NumberFormatException) {
+                if (it.isBlank()) {
+                    onDurationChange("0")
+                }
+            }
+        },
+        label = { Text("") },
+        singleLine = true,
+        modifier = modifier
+            .height(60.dp)
+            .border(1.dp, Color.Gray, RoundedCornerShape(15.dp))
+            .fillMaxWidth(),
+        colors = TextFieldDefaults.outlinedTextFieldColors(
+            textColor = Color.Black,
+            cursorColor = Color.Black,
+            backgroundColor = Color.White,
+            focusedBorderColor = Color.Transparent,
+            unfocusedBorderColor = Color.Transparent
+        ),
+        textStyle = TextStyle(
+            fontSize = 15.sp,
+            color = Color.Black,
+            textAlign = TextAlign.Center
+        )
+    )
+}
+
+
+@Composable
+fun CustomTimePickerDialog(
+    initialTime: String,
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val validInitialTime = if (initialTime.matches(Regex("\\d{2}:\\d{2}"))) initialTime else "12:00"
+    var selectedHour by remember { mutableStateOf(validInitialTime.split(":").first().toInt()) }
+    var selectedMinute by remember { mutableStateOf(validInitialTime.split(":").last().toInt()) }
+    var showDialog by remember { mutableStateOf(true) }
+
+    if (showDialog) {
+        AlertDialog(
+            onDismissRequest = {
+                showDialog = false
+                onDismiss()},
+            confirmButton = {
+                TextButton(onClick = {
+                    val formattedTime = String.format("%02d:%02d", selectedHour, selectedMinute)
+                    onConfirm(formattedTime)
+                    showDialog = false
+                }) {
+                    Text("확인")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showDialog = false
+                    onDismiss() }
+                )
+                {
+                    Text("취소")
+                }
+            },
+            text = {
+                Row(modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center) {
+                    AndroidView(
+                        factory = { context ->
+                            NumberPicker(context).apply {
+                                minValue = 0
+                                maxValue = 23
+                                value = selectedHour
+                                setOnValueChangedListener { _, _, newVal ->
+                                    selectedHour = newVal
+                                }
+                            }
+                        }
+                    )
+                    Spacer(Modifier.width(20.dp))
+                    AndroidView(
+                        factory = { context ->
+                            NumberPicker(context).apply {
+                                minValue = 0
+                                maxValue = 59
+                                value = selectedMinute
+                                setOnValueChangedListener { _, _, newVal ->
+                                    selectedMinute = newVal
+                                }
+                            }
+                        }
+                    )
+                }
+            }
+        )
     }
 }

--- a/app/src/main/java/com/imhungry/jjongseol/ui/profilecard/ProfileScreen.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/profilecard/ProfileScreen.kt
@@ -1,11 +1,14 @@
 package com.imhungry.jjongseol.ui.profilecard
 
 import android.app.DatePickerDialog
+import android.widget.NumberPicker
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -18,11 +21,13 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.AlertDialog
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.Icon
 import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.TextButton
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
@@ -45,10 +50,14 @@ import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
 import java.util.Calendar
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.constraintlayout.compose.Dimension
+import androidx.constraintlayout.compose.VerticalAlign
 import androidx.navigation.NavController
 import com.imhungry.jjongseol.R
 import com.imhungry.jjongseol.ui.theme.md_theme_button_color_blue
+import java.time.LocalDate
+import java.time.YearMonth
 
 @Composable
 fun MakeProfile(navController: NavController) {
@@ -232,7 +241,7 @@ fun MakeProfile(navController: NavController) {
                                 )
                             )
                         }
-                        DatePickerField()
+                        DatePickerDialog()
                     }
                     Column(modifier = Modifier.weight(1f)){
                         Box(
@@ -526,7 +535,10 @@ fun MBTIPickerField() {
 
     Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
         Row(modifier = Modifier
-            .clickable { expanded = !expanded }
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null
+            )  { expanded = !expanded }
             .padding(8.dp)
             .height(55.dp)
             .border(1.dp, Color.Gray, RoundedCornerShape(15.dp)),
@@ -555,54 +567,105 @@ fun MBTIPickerField() {
     }
 }
 
-
 @Composable
-fun DatePickerField() {
+fun DatePickerDialog() {
     val context = LocalContext.current
-    val calendar = remember { Calendar.getInstance() }
-    val year = calendar.get(Calendar.YEAR)
-    val month = calendar.get(Calendar.MONTH)
-    val day = calendar.get(Calendar.DAY_OF_MONTH)
+    val initialYearMonthDay = remember { LocalDate.now() }
+    var selectedYear by remember { mutableStateOf(initialYearMonthDay.year) }
+    var selectedMonth by remember { mutableStateOf(initialYearMonthDay.monthValue) }
+    var selectedDay by remember { mutableStateOf(initialYearMonthDay.dayOfMonth) }
+    var daysInMonth = remember(selectedYear, selectedMonth) {
+        YearMonth.of(selectedYear, selectedMonth).lengthOfMonth()
+    }
 
+    val showDatePickerDialog = remember { mutableStateOf(false) }
     val dateText = remember { mutableStateOf("YYYY / MM / DD") }
-    val textColor = if (dateText.value == "YYYY / MM / DD") Color.LightGray else Color.Black
 
-    val datePickerDialog = DatePickerDialog(
-        context,
-        { _, selectedYear, selectedMonth, selectedDay ->
-            dateText.value = "${selectedYear} / ${selectedMonth + 1} / $selectedDay"
-        }, year, month, day
-    )
-
-    Box(
+    Row(
         modifier = Modifier
             .fillMaxWidth()
-            .height(70.dp)
             .padding(8.dp)
+            .height(55.dp)
             .border(1.dp, Color.Gray, RoundedCornerShape(15.dp))
-            .clickable {
-                datePickerDialog.show()
-            },
-        contentAlignment = Alignment.CenterStart
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null
+            ) { showDatePickerDialog.value = true },
+        horizontalArrangement  = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = dateText.value,
-                style = TextStyle(
-                    color = textColor,
-                    fontSize = 16.sp
-                ),
-                modifier = Modifier.padding(start = 5.dp)
-            )
-            Spacer(Modifier.weight(1f))
-            Icon(
-                imageVector = Icons.Filled.DateRange,
-                contentDescription = "생일",
-                modifier = Modifier.align(Alignment.CenterVertically)
-            )
-        }
+        Text(
+            text = dateText.value,
+            style = TextStyle(fontSize = 16.sp, color = Color.Black),
+            modifier = Modifier.padding(start = 20.dp, top = 10.dp, bottom = 10.dp)
+        )
+        Spacer(Modifier.weight(1f))
+
+        Icon(
+            imageVector = Icons.Filled.DateRange,
+            contentDescription = "생일 선택",
+            modifier = Modifier.padding(end = 10.dp)
+        )
+    }
+
+    if (showDatePickerDialog.value) {
+        AlertDialog(
+            onDismissRequest = { showDatePickerDialog.value = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    dateText.value = "$selectedYear / $selectedMonth / $selectedDay"
+                    showDatePickerDialog.value = false
+                }) {
+                    Text(text = "확인", color = md_theme_button_color_blue,
+                        modifier = Modifier.padding(10.dp))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDatePickerDialog.value = false }) {
+                    Text(text = "취소", color = md_theme_button_color_blue,
+                        modifier = Modifier.padding(10.dp))
+                }
+            },
+            text = {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceEvenly
+                ) {
+                    NumberPickerComponent("", 1900, 2125, selectedYear) { newVal ->
+                        selectedYear = newVal
+                        daysInMonth = YearMonth.of(selectedYear, selectedMonth).lengthOfMonth()
+                        selectedDay = minOf(selectedDay, daysInMonth)
+                    }
+                    NumberPickerComponent("", 1, 12, selectedMonth) { newVal ->
+                        selectedMonth = newVal
+                        daysInMonth = YearMonth.of(selectedYear, selectedMonth).lengthOfMonth()
+                        selectedDay = minOf(selectedDay, daysInMonth)
+                    }
+                    NumberPickerComponent("", 1, daysInMonth, selectedDay) { newVal ->
+                        selectedDay = newVal
+                    }
+                }
+            }
+        )
+    }
+}
+
+@Composable
+fun NumberPickerComponent(label: String, min: Int, max: Int, value: Int, onValueChange: (Int) -> Unit) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(text = label)
+        AndroidView(
+            factory = { context ->
+                NumberPicker(context).apply {
+                    minValue = min
+                    maxValue = max
+                    setValue(value)
+                    setOnValueChangedListener { _, _, newVal ->
+                        onValueChange(newVal)
+                    }
+                }
+            },
+            update = { it.maxValue = max; it.minValue = min; it.value = value }
+        )
     }
 }


### PR DESCRIPTION
- 홈 화면
캘린더 일정 추가
회의 기록 및 예정된 회의 토글 접는 부분 확장

- 회의 생성 화면
회의 날짜 선택 방식 변경(예쁜 달력에서 선택)
회의 시간 선택 방식 변경(picker -> 스크롤 방식)

- 프로필 생성 화면
생일 선택 방식 변경(달력에서 선택 -> 스크롤 방식)

- 회의 데이터 형식 파일 추가