### PR TITLE
refactor: MeetingViewModel 책임 분리 및 예외 처리 개선

### DIFF
--- a/app/src/main/java/com/imhungry/jjongseol/controller/StreamingController.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/controller/StreamingController.kt
@@ -1,0 +1,37 @@
+package com.imhungry.jjongseol.controller
+
+import android.app.Application
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import com.imhungry.jjongseol.service.AudioStreamingService
+import javax.inject.Inject
+
+class StreamingController @Inject constructor(
+    private val application: Application
+) {
+
+    fun startStreamingService() {
+        val prefs = application.getSharedPreferences("meeting_prefs", Context.MODE_PRIVATE)
+        if (!prefs.contains("meetingStartedAt")) {
+            prefs.edit().putBoolean("isMeetingOngoing", true)
+                .putLong("meetingStartedAt", System.currentTimeMillis()).apply()
+        }
+
+        val intent = Intent(application, AudioStreamingService::class.java)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+            application.startForegroundService(intent)
+        else
+            application.startService(intent)
+    }
+
+    fun stopStreamingService() {
+        application.getSharedPreferences("meeting_prefs", Context.MODE_PRIVATE).edit()
+            .putBoolean("isMeetingOngoing", false)
+            .remove("meetingStartedAt").apply()
+        application.stopService(Intent(application, AudioStreamingService::class.java))
+    }
+
+    fun pauseEncoding() = AudioStreamingService.pauseEncoding()
+    fun resumeEncoding() = AudioStreamingService.resumeEncoding()
+}

--- a/app/src/main/java/com/imhungry/jjongseol/controller/TestDataSender.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/controller/TestDataSender.kt
@@ -1,0 +1,69 @@
+package com.imhungry.jjongseol.controller
+
+import com.imhungry.jjongseol.data.network.FeedbackApi
+import com.imhungry.jjongseol.data.network.ParticipationRateApi
+import com.imhungry.jjongseol.data.network.SummaryApi
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class TestDataSender @Inject constructor(
+    private val summaryApi: SummaryApi,
+    private val participationRateApi: ParticipationRateApi,
+    private val feedbackApi: FeedbackApi
+) {
+    private var summaryJob: Job? = null
+    private var participationJob: Job? = null
+    private var feedbackJob: Job? = null
+
+    fun startSummary(meetingId: Long, scope: CoroutineScope) {
+        if (summaryJob?.isActive == true) return
+        summaryJob = scope.launch {
+            while (isActive) {
+                runCatching { summaryApi.sendTestSummary(meetingId) }
+                    .onFailure { println("요약 전송 실패: ${it.message}") }
+                delay(5000)
+            }
+        }
+    }
+
+    fun stopSummary() {
+        summaryJob?.cancel()
+        summaryJob = null
+    }
+
+    fun startParticipation(meetingId: Long, scope: CoroutineScope) {
+        if (participationJob?.isActive == true) return
+        participationJob = scope.launch {
+            while (isActive) {
+                runCatching { participationRateApi.sendTestParticipationRate(meetingId) }
+                    .onFailure { println("점유율 전송 실패: ${it.message}") }
+                delay(5000)
+            }
+        }
+    }
+
+    fun stopParticipation() {
+        participationJob?.cancel()
+        participationJob = null
+    }
+
+    fun startFeedback(meetingId: Long, scope: CoroutineScope) {
+        if (feedbackJob?.isActive == true) return
+        feedbackJob = scope.launch {
+            while (isActive) {
+                runCatching { feedbackApi.sendTestFeedback(meetingId) }
+                    .onFailure { println("피드백 전송 실패: ${it.message}") }
+                delay(5000)
+            }
+        }
+    }
+
+    fun stopFeedback() {
+        feedbackJob?.cancel()
+        feedbackJob = null
+    }
+}

--- a/app/src/main/java/com/imhungry/jjongseol/data/model/ApiResponse.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/data/model/ApiResponse.kt
@@ -1,0 +1,6 @@
+package com.imhungry.jjongseol.data.model
+
+data class ApiResponse<T>(
+    val message: String,
+    val data: T
+)

--- a/app/src/main/java/com/imhungry/jjongseol/data/network/AgendaApi.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/data/network/AgendaApi.kt
@@ -1,10 +1,11 @@
 package com.imhungry.jjongseol.data.network
 
+import com.imhungry.jjongseol.data.model.ApiResponse
 import com.imhungry.jjongseol.data.model.agenda.AgendaListResponse
 import retrofit2.http.GET
 import retrofit2.http.Path
 
 interface AgendaApi {
     @GET("api/agendas/{meetingId}")
-    suspend fun getAgendas(@Path("meetingId") meetingId: Long): AgendaListResponse
+    suspend fun getAgendas(@Path("meetingId") meetingId: Long): ApiResponse<AgendaListResponse>
 }

--- a/app/src/main/java/com/imhungry/jjongseol/data/network/RetrofitModule.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/data/network/RetrofitModule.kt
@@ -23,6 +23,9 @@ object RetrofitModule {
     fun provideOkHttpClient(authInterceptor: AuthInterceptor): OkHttpClient {
         return OkHttpClient.Builder()
             .addInterceptor(authInterceptor)
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(0, TimeUnit.SECONDS)
+            .writeTimeout(10, TimeUnit.SECONDS)
             .build()
     }
 

--- a/app/src/main/java/com/imhungry/jjongseol/data/repository/AgendaRepository.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/data/repository/AgendaRepository.kt
@@ -3,15 +3,20 @@ package com.imhungry.jjongseol.data.repository
 import android.util.Log
 import com.imhungry.jjongseol.data.model.agenda.AgendaDto
 import com.imhungry.jjongseol.data.network.AgendaApi
+import com.imhungry.jjongseol.util.handleHttpException
+import retrofit2.HttpException
 import javax.inject.Inject
 
 class AgendaRepository @Inject constructor(
     private val agendaApi: AgendaApi
 ) {
     suspend fun getAgendas(meetingId: Long): List<AgendaDto> {
-        val response = agendaApi.getAgendas(meetingId)
-        Log.d("Agenda", "Api 응답: $response")
-        return response.data.agendaDetails
+        return try {
+            agendaApi.getAgendas(meetingId).data.agendaDetails
+        } catch (e: HttpException) {
+            val error = handleHttpException(e)
+            throw RuntimeException(error.message ?: "알 수 없는 오류 발생")
+        }
     }
 }
 

--- a/app/src/main/java/com/imhungry/jjongseol/data/repository/AgendaRepository.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/data/repository/AgendaRepository.kt
@@ -8,7 +8,8 @@ class AgendaRepository @Inject constructor(
     private val agendaApi: AgendaApi
 ) {
     suspend fun getAgendas(meetingId: Long): List<AgendaDto> {
-        return agendaApi.getAgendas(meetingId).agendaDetails
+        val response = agendaApi.getAgendas(meetingId)
+        return response.data.agendaDetails
     }
 }
 

--- a/app/src/main/java/com/imhungry/jjongseol/data/repository/AgendaRepository.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/data/repository/AgendaRepository.kt
@@ -1,5 +1,6 @@
 package com.imhungry.jjongseol.data.repository
 
+import android.util.Log
 import com.imhungry.jjongseol.data.model.agenda.AgendaDto
 import com.imhungry.jjongseol.data.network.AgendaApi
 import javax.inject.Inject
@@ -9,6 +10,7 @@ class AgendaRepository @Inject constructor(
 ) {
     suspend fun getAgendas(meetingId: Long): List<AgendaDto> {
         val response = agendaApi.getAgendas(meetingId)
+        Log.d("Agenda", "Api 응답: $response")
         return response.data.agendaDetails
     }
 }

--- a/app/src/main/java/com/imhungry/jjongseol/data/repository/LoginRepository.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/data/repository/LoginRepository.kt
@@ -1,7 +1,10 @@
 package com.imhungry.jjongseol.data.repository
 
 import android.content.Context
+import android.util.Base64
+import com.google.gson.JsonParser
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.nio.charset.Charset
 import javax.inject.Inject
 
 class LoginRepository @Inject constructor(
@@ -15,5 +18,24 @@ class LoginRepository @Inject constructor(
 
     fun getToken(): String? = sharedPrefs.getString("jwt_token", null)
 
-    fun isLoggedIn(): Boolean = !getToken().isNullOrEmpty()
+    fun isLoggedIn(): Boolean {
+        val token = getToken() ?: return false
+        return !isTokenExpired(token)
+    }
+
+    private fun isTokenExpired(token: String): Boolean {
+        return try {
+            val parts = token.split(".")
+            if (parts.size != 3) return true
+
+            val payloadJson = String(Base64.decode(parts[1], Base64.URL_SAFE), Charset.defaultCharset())
+            val jsonObj = JsonParser.parseString(payloadJson).asJsonObject
+
+            val exp = jsonObj["exp"]?.asLong ?: return true
+            val now = System.currentTimeMillis() / 1000
+            now >= exp
+        } catch (e: Exception) {
+            true
+        }
+    }
 }

--- a/app/src/main/java/com/imhungry/jjongseol/ui/meeting/MeetingScreen.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/meeting/MeetingScreen.kt
@@ -1,7 +1,6 @@
 package com.imhungry.jjongseol.ui.meeting
 
 import android.Manifest
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
@@ -9,25 +8,28 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Divider
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
 import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.google.accompanist.pager.ExperimentalPagerApi
@@ -36,36 +38,113 @@ import com.google.accompanist.pager.HorizontalPagerIndicator
 import com.google.accompanist.pager.rememberPagerState
 import com.imhungry.jjongseol.R
 import com.imhungry.jjongseol.ui.SilRokNavigation
+import com.imhungry.jjongseol.ui.component.CustomDialog
 import com.imhungry.jjongseol.ui.meeting.bottom.MeetingControlPanel
 import com.imhungry.jjongseol.ui.meeting.pager.MeetingFeedbackScreen
 import com.imhungry.jjongseol.ui.meeting.pager.MeetingRecordScreen
 import com.imhungry.jjongseol.ui.meeting.pager.MeetingSummaryScreen
+import com.imhungry.jjongseol.viewmodel.AgendaViewModel
 import com.imhungry.jjongseol.viewmodel.MeetingViewModel
 import kotlinx.coroutines.delay
 
 @Composable
 fun MeetingScreen(
-    viewModel: MeetingViewModel = hiltViewModel(),
+    meetingViewModel: MeetingViewModel = hiltViewModel(),
+    agendaViewModel: AgendaViewModel = hiltViewModel(),
     onFinish: (SilRokNavigation) -> Unit,
     meetingId: Long
 ) {
+    val agendaItems by agendaViewModel.agendaItems.collectAsState()
+    val checkedStates by agendaViewModel.checkedStates.collectAsState()
+    val isAgendaLoading = agendaItems.isEmpty() || checkedStates.size != agendaItems.size
+    val errorMessage by meetingViewModel.errorMessage.collectAsState()
+    val showDialog = remember { mutableStateOf(false) }
+    val timeText by rememberMeetingStartTime()
+
+    LaunchedEffect(meetingId) {
+        agendaViewModel.onError = { meetingViewModel.setErrorMessage(it) }
+        agendaViewModel.loadAgendas(meetingId)
+    }
+
+    if (errorMessage != null) {
+        showDialog.value = true
+    }
+
+    if (showDialog.value && errorMessage != null) {
+        CustomDialog(
+            description = if (errorMessage == "TOKEN_EXPIRED")
+                "로그인 정보가 만료되었어요. 다시 로그인해주세요."
+            else errorMessage,
+            confirmText = if (errorMessage == "TOKEN_EXPIRED") "로그인 하기" else "홈으로",
+            showDismissButton = false,
+            onDismissRequest = {},
+            onConfirmExit = {
+                showDialog.value = false
+                meetingViewModel.clearErrorMessage()
+                val dest = if (errorMessage == "TOKEN_EXPIRED") SilRokNavigation.Login else SilRokNavigation.Home
+                onFinish(dest)
+            }
+        )
+    }
+
+    PermissionHandler {
+        MeetingInitController(
+            allReady = !isAgendaLoading,
+            meetingViewModel = meetingViewModel,
+            meetingId = meetingId,
+            timeProvider = { timeText }
+        )
+
+        if (isAgendaLoading) {
+            Box(
+                modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(color = Color(0xFF86CC3B))
+            }
+        } else {
+            MeetingScreenContent(
+                onFinish = onFinish,
+                onExitConfirmed = {
+                    meetingViewModel.stopStreamingService()
+                    meetingViewModel.stopSendingTestSummary()
+                    meetingViewModel.stopSendingTestParticipationRate()
+                    meetingViewModel.stopSendingTestFeedback()
+                    meetingViewModel.stopSse()
+                },
+                viewModel = meetingViewModel,
+                meetingId = meetingId,
+                timeText = timeText,
+            )
+        }
+    }
+}
+
+@Composable
+private fun MeetingInitController(
+    allReady: Boolean,
+    meetingViewModel: MeetingViewModel,
+    meetingId: Long,
+    timeProvider: () -> String
+) {
+    LaunchedEffect(allReady) {
+        if (allReady) {
+            meetingViewModel.startStreamingService()
+            meetingViewModel.resumeEncoding()
+            meetingViewModel.subscribeToSummary(meetingId, timeProvider)
+            meetingViewModel.startSendingTestSummary(meetingId)
+            meetingViewModel.subscribeToParticipationRate(meetingId)
+            meetingViewModel.startSendingTestParticipationRate(meetingId)
+            meetingViewModel.subscribeToFeedback(meetingId, timeProvider)
+            meetingViewModel.startSendingTestFeedback(meetingId)
+        }
+    }
+}
+
+@Composable
+private fun rememberMeetingStartTime(): State<String> {
     val context = LocalContext.current
-    var audioPermissionGranted by remember { mutableStateOf(false) }
-    var notificationPermissionGranted by remember { mutableStateOf(false) }
-
-    val audioPermissionLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestPermission()
-    ) { isGranted ->
-        audioPermissionGranted = isGranted
-    }
-
-    val notificationPermissionLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestPermission()
-    ) { isGranted ->
-        notificationPermissionGranted = isGranted
-    }
-
-    val startTimeMillis = remember {
+    val startTime = remember {
         val prefs = context.getSharedPreferences("meeting_prefs", Context.MODE_PRIVATE)
         prefs.getLong("meetingStartedAt", System.currentTimeMillis())
     }
@@ -73,102 +152,82 @@ fun MeetingScreen(
     var elapsedSeconds by remember { mutableStateOf(0) }
 
     LaunchedEffect(Unit) {
-        val audioGranted = ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.RECORD_AUDIO
-        ) == PackageManager.PERMISSION_GRANTED
-
-        if (audioGranted) {
-            audioPermissionGranted = true
-        } else {
-            audioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
-        }
-    }
-
-    LaunchedEffect(Unit) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            val notificationGranted = ContextCompat.checkSelfPermission(
-                context,
-                Manifest.permission.POST_NOTIFICATIONS
-            ) == PackageManager.PERMISSION_GRANTED
-
-            if (!notificationGranted) {
-                notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-            } else {
-                notificationPermissionGranted = true
-            }
-        } else {
-            notificationPermissionGranted = true
-        }
-    }
-
-    LaunchedEffect(Unit) {
         while (true) {
-            val now = System.currentTimeMillis()
-            elapsedSeconds = ((now - startTimeMillis) / 1000).toInt()
+            elapsedSeconds = ((System.currentTimeMillis() - startTime) / 1000).toInt()
             delay(1000)
         }
     }
 
-    val timeText = remember(elapsedSeconds) {
-        val hours = elapsedSeconds / 3600
-        val minutes = (elapsedSeconds % 3600) / 60
-        val seconds = elapsedSeconds % 60
-        String.format("%02d:%02d:%02d", hours, minutes, seconds)
+    return remember(elapsedSeconds) {
+        derivedStateOf {
+            val h = elapsedSeconds / 3600
+            val m = (elapsedSeconds % 3600) / 60
+            val s = elapsedSeconds % 60
+            String.format("%02d:%02d:%02d", h, m, s)
+        }
+    }
+}
+
+@Composable
+private fun PermissionHandler(onGranted: @Composable () -> Unit) {
+    val context = LocalContext.current
+    var granted by remember { mutableStateOf(false) }
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions()
+    ) { perms ->
+        granted = perms[Manifest.permission.RECORD_AUDIO] == true &&
+                (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+                        perms[Manifest.permission.POST_NOTIFICATIONS] == true)
     }
 
-    val currentTimeText by rememberUpdatedState(timeText)
+    LaunchedEffect(Unit) {
+        val audio = ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED
+        val notify = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
+        } else true
 
-    LaunchedEffect(audioPermissionGranted, notificationPermissionGranted) {
-        if (audioPermissionGranted && notificationPermissionGranted) {
-            viewModel.startStreamingService()
-            viewModel.resumeEncoding()
+        granted = audio && notify
 
-            viewModel.subscribeToSummary(meetingId) { currentTimeText }
-            viewModel.startSendingTestSummary(meetingId)
-            viewModel.subscribeToParticipationRate(meetingId)
-            viewModel.startSendingTestParticipationRate(meetingId)
-            viewModel.subscribeToFeedback(meetingId) { currentTimeText }
-            viewModel.startSendingTestFeedback(meetingId)
+        if (!granted) {
+            val req = mutableListOf(Manifest.permission.RECORD_AUDIO)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+                req.add(Manifest.permission.POST_NOTIFICATIONS)
+            launcher.launch(req.toTypedArray())
         }
     }
 
-    MeetingScreenContent(
-        onFinish = onFinish,
-        onExitConfirmed = {
-            viewModel.stopStreamingService()
-            viewModel.stopSendingTestSummary()
-            viewModel.stopSendingTestParticipationRate()
-            viewModel.stopSendingTestFeedback()
-            viewModel.stopSse()
-        },
-        meetingId = meetingId,
-        timeText = timeText
-    )
+    if (granted) onGranted()
 }
 
-@SuppressLint("DefaultLocale")
 @OptIn(ExperimentalPagerApi::class)
 @Composable
 fun MeetingScreenContent(
     onFinish: (SilRokNavigation) -> Unit,
     onExitConfirmed: () -> Unit,
-    viewModel: MeetingViewModel = hiltViewModel(),
+    viewModel: MeetingViewModel,
     meetingId: Long,
     timeText: String
 ) {
-    Column(modifier = Modifier
-        .fillMaxSize()
-        .background(MaterialTheme.colorScheme.background)
+    val pagerState = rememberPagerState(initialPage = 1)
+
+    ConstraintLayout(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
     ) {
-        val pagerState = rememberPagerState(initialPage = 1)
+        val (pager, indicator, divider, control) = createRefs()
 
         HorizontalPager(
             count = 3,
             state = pagerState,
             modifier = Modifier
+                .constrainAs(pager) {
+                    top.linkTo(parent.top)
+                    bottom.linkTo(indicator.top)
+                    height = Dimension.fillToConstraints
+                }
                 .fillMaxWidth()
-                .weight(0.70f)
         ) { page ->
             when (page) {
                 0 -> MeetingSummaryScreen()
@@ -180,46 +239,44 @@ fun MeetingScreenContent(
         HorizontalPagerIndicator(
             pagerState = pagerState,
             modifier = Modifier
-                .align(Alignment.CenterHorizontally)
-                .padding(top = 4.dp, bottom = 4.dp),
+                .padding(top = 12.dp, bottom = 12.dp)
+                .constrainAs(indicator) {
+                    top.linkTo(pager.bottom)
+                    bottom.linkTo(divider.top)
+                    centerHorizontallyTo(parent)
+                },
             activeColor = Color(0xFF1E93EF),
             inactiveColor = Color.LightGray,
             indicatorWidth = 6.dp,
             spacing = 4.dp
         )
 
-        Box(
+        Divider(
+            thickness = 1.dp,
             modifier = Modifier
                 .fillMaxWidth()
-                .height(16.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Divider(
-                color = Color.LightGray,
-                thickness = 1.dp,
-                modifier = Modifier.fillMaxWidth()
-            )
-        }
+                .constrainAs(divider) {
+                    top.linkTo(indicator.bottom)
+                    bottom.linkTo(control.top)
+                }
+        )
 
         MeetingControlPanel(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(0.20f),
             timeText = timeText,
             micEnabled = true,
-            onMicToggle = { isMicOn ->
-                if (isMicOn) {
-                    viewModel.resumeEncoding()
-                } else {
-                    viewModel.pauseEncoding()
-                }
-            },
+            onMicToggle = { if (it) viewModel.resumeEncoding() else viewModel.pauseEncoding() },
             micIcon = R.drawable.micoff,
             logoutIcon = R.drawable.logout,
             powerIcon = R.drawable.power,
             onFinish = onFinish,
             onExitConfirmed = onExitConfirmed,
-            viewModel = viewModel
+            viewModel = viewModel,
+            modifier = Modifier
+                .constrainAs(control) {
+                    bottom.linkTo(parent.bottom)
+                    start.linkTo(parent.start)
+                    end.linkTo(parent.end)
+                }
         )
     }
 }

--- a/app/src/main/java/com/imhungry/jjongseol/ui/meeting/MeetingScreen.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/meeting/MeetingScreen.kt
@@ -62,7 +62,9 @@ fun MeetingScreen(
     val timeText by rememberMeetingStartTime()
 
     LaunchedEffect(meetingId) {
-        agendaViewModel.onError = { meetingViewModel.setErrorMessage(it) }
+        agendaViewModel.onError = { apiError ->
+            meetingViewModel.setError(apiError)
+        }
         agendaViewModel.loadAgendas(meetingId)
     }
 
@@ -70,19 +72,21 @@ fun MeetingScreen(
         showDialog.value = true
     }
 
+    val isTokenExpired = errorMessage == "TOKEN_EXPIRED"
+
     if (showDialog.value && errorMessage != null) {
         CustomDialog(
-            description = if (errorMessage == "TOKEN_EXPIRED")
-                "로그인 정보가 만료되었어요. 다시 로그인해주세요."
+            description = if (isTokenExpired)
+                "로그인 정보가 만료되었어요.\n다시 로그인해주세요."
             else errorMessage,
-            confirmText = if (errorMessage == "TOKEN_EXPIRED") "로그인 하기" else "홈으로",
+            confirmText = if (isTokenExpired) "로그인 하기" else "홈으로",
             showDismissButton = false,
             onDismissRequest = {},
             onConfirmExit = {
                 showDialog.value = false
                 meetingViewModel.clearErrorMessage()
-                val dest = if (errorMessage == "TOKEN_EXPIRED") SilRokNavigation.Login else SilRokNavigation.Home
-                onFinish(dest)
+                val destination = if (isTokenExpired) SilRokNavigation.Login else SilRokNavigation.Home
+                onFinish(destination)
             }
         )
     }

--- a/app/src/main/java/com/imhungry/jjongseol/ui/meeting/MeetingScreen.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/meeting/MeetingScreen.kt
@@ -107,9 +107,7 @@ fun MeetingScreen(
                 onFinish = onFinish,
                 onExitConfirmed = {
                     meetingViewModel.stopStreamingService()
-                    meetingViewModel.stopSendingTestSummary()
-                    meetingViewModel.stopSendingTestParticipationRate()
-                    meetingViewModel.stopSendingTestFeedback()
+                    meetingViewModel.stopSendingTestData()
                     meetingViewModel.stopSse()
                 },
                 viewModel = meetingViewModel,
@@ -132,11 +130,9 @@ private fun MeetingInitController(
             meetingViewModel.startStreamingService()
             meetingViewModel.resumeEncoding()
             meetingViewModel.subscribeToSummary(meetingId, timeProvider)
-            meetingViewModel.startSendingTestSummary(meetingId)
             meetingViewModel.subscribeToParticipationRate(meetingId)
-            meetingViewModel.startSendingTestParticipationRate(meetingId)
             meetingViewModel.subscribeToFeedback(meetingId, timeProvider)
-            meetingViewModel.startSendingTestFeedback(meetingId)
+            meetingViewModel.startSendingTestData(meetingId)
         }
     }
 }

--- a/app/src/main/java/com/imhungry/jjongseol/ui/meeting/MeetingWaitingScreen.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/meeting/MeetingWaitingScreen.kt
@@ -49,10 +49,9 @@ fun MeetingWaitingScreen(
     val errorMessage by meetingViewModel.errorMessage.collectAsState()
     val showDialog = remember { mutableStateOf(false) }
 
-    // 아젠다 로딩 시작
     LaunchedEffect(meetingId) {
-        agendaViewModel.onError = {
-            meetingViewModel.setErrorMessage(it)
+        agendaViewModel.onError = { apiError ->
+            meetingViewModel.setError(apiError)
         }
         agendaViewModel.loadAgendas(meetingId)
     }
@@ -113,19 +112,20 @@ private fun ErrorDialogSection(
     meetingViewModel: MeetingViewModel
 ) {
     if (errorMessage != null) showDialog.value = true
+    val isTokenExpired = errorMessage == "TOKEN_EXPIRED"
 
     if (showDialog.value && errorMessage != null) {
         CustomDialog(
-            description = if (errorMessage == "TOKEN_EXPIRED")
-                "로그인 정보가 만료되었어요. 다시 로그인해주세요."
+            description = if (isTokenExpired)
+                "로그인 정보가 만료되었어요.\n다시 로그인해주세요."
             else errorMessage,
-            confirmText = if (errorMessage == "TOKEN_EXPIRED") "로그인 하기" else "홈으로",
+            confirmText = if (isTokenExpired) "로그인 하기" else "홈으로",
             showDismissButton = false,
             onDismissRequest = {},
             onConfirmExit = {
                 showDialog.value = false
                 meetingViewModel.clearErrorMessage()
-                val destination = if (errorMessage == "TOKEN_EXPIRED") SilRokNavigation.Login else SilRokNavigation.Home
+                val destination = if (isTokenExpired) SilRokNavigation.Login else SilRokNavigation.Home
                 onFinish(destination)
             }
         )

--- a/app/src/main/java/com/imhungry/jjongseol/ui/meeting/MeetingWaitingScreen.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/meeting/MeetingWaitingScreen.kt
@@ -149,7 +149,7 @@ private fun MeetingContent(
     viewModel: MeetingViewModel
 ) {
     Box(modifier = Modifier.fillMaxWidth()) {
-        val isLoading = agendas.isEmpty() || checkedStates.isEmpty() || peekIndex !in agendas.indices
+        val isLoading = agendas.isNullOrEmpty() || checkedStates.isNullOrEmpty() || peekIndex !in agendas.indices
 
         if (isLoading) {
             Box(

--- a/app/src/main/java/com/imhungry/jjongseol/ui/meeting/MeetingWaitingScreen.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/meeting/MeetingWaitingScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Divider
 import androidx.compose.material3.CircularProgressIndicator
@@ -23,37 +22,33 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.google.accompanist.pager.ExperimentalPagerApi
-import com.google.accompanist.pager.HorizontalPagerIndicator
-import com.google.accompanist.pager.rememberPagerState
 import com.imhungry.jjongseol.R
-import com.imhungry.jjongseol.data.model.agenda.AgendaDto
 import com.imhungry.jjongseol.ui.SilRokNavigation
 import com.imhungry.jjongseol.ui.component.CheckItem
 import com.imhungry.jjongseol.ui.component.CustomDialog
 import com.imhungry.jjongseol.ui.component.TopSheet
 import com.imhungry.jjongseol.ui.meeting.bottom.MeetingControlPanel
+import com.imhungry.jjongseol.viewmodel.AgendaViewModel
 import com.imhungry.jjongseol.viewmodel.MeetingViewModel
 
-@OptIn(ExperimentalPagerApi::class)
 @Composable
 fun MeetingWaitingScreen(
-    viewModel: MeetingViewModel = hiltViewModel(),
+    meetingViewModel: MeetingViewModel = hiltViewModel(),
+    agendaViewModel: AgendaViewModel = hiltViewModel(),
     onFinish: (SilRokNavigation) -> Unit,
     meetingId: Long = 1L
 ) {
-    val agendas by viewModel.agendaItems.collectAsState()
-    val checkedStates by viewModel.checkedStates.collectAsState()
-    val errorMessage by viewModel.errorMessage.collectAsState()
+    val agendas by agendaViewModel.agendaItems.collectAsState()
+    val checkedStates by agendaViewModel.checkedStates.collectAsState()
+    val errorMessage by meetingViewModel.errorMessage.collectAsState()
     val showDialog = remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
-        viewModel.loadAgendas(meetingId)
+        agendaViewModel.loadAgendas(meetingId)
     }
 
     if (errorMessage != null) {
@@ -62,123 +57,31 @@ fun MeetingWaitingScreen(
 
     if (showDialog.value && errorMessage != null) {
         CustomDialog(
-            description = if (errorMessage == "TOKEN_EXPIRED") "로그인 정보가 만료되었어요. 다시 로그인해주세요." else errorMessage,
+            description = if (errorMessage == "TOKEN_EXPIRED")
+                "로그인 정보가 만료되었어요. 다시 로그인해주세요."
+            else errorMessage,
             confirmText = if (errorMessage == "TOKEN_EXPIRED") "로그인 하기" else "홈으로",
             showDismissButton = false,
             onDismissRequest = {},
             onConfirmExit = {
                 showDialog.value = false
-                viewModel.clearErrorMessage()
-                if (errorMessage == "TOKEN_EXPIRED") {
-                    onFinish(SilRokNavigation.Login)
-                } else {
-                    onFinish(SilRokNavigation.Home)
-                }
+                meetingViewModel.clearErrorMessage()
+                val destination = if (errorMessage == "TOKEN_EXPIRED") SilRokNavigation.Login else SilRokNavigation.Home
+                onFinish(destination)
             }
         )
     }
 
-    val lastCheckedIndex = remember { mutableStateOf(0) }
     val firstUncheckedIndex = checkedStates.indexOfFirst { !it }
-    val peekIndex = if (firstUncheckedIndex == -1) lastCheckedIndex.value else firstUncheckedIndex
+    val peekIndex = if (firstUncheckedIndex == -1) checkedStates.lastIndex else firstUncheckedIndex
+    val isLoading = isLoading(peekIndex, agendas, checkedStates)
 
     Column(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
     ) {
-        Box(modifier = Modifier.weight(0.70f)) {
-            MeetingContent(
-                onFinish = onFinish,
-                agendas = agendas,
-                checkedStates = checkedStates,
-                peekIndex = peekIndex,
-                firstUncheckedIndex = firstUncheckedIndex,
-                viewModel = viewModel
-            )
-        }
-
-        HorizontalPagerIndicator(
-            pagerState = rememberPagerState(initialPage = 1),
-            modifier = Modifier
-                .align(Alignment.CenterHorizontally)
-                .padding(vertical = 4.dp)
-                .alpha(0f),
-            activeColor = Color(0xFF1E93EF),
-            inactiveColor = Color.LightGray,
-            indicatorWidth = 6.dp,
-            spacing = 4.dp
-        )
-
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(16.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Divider(
-                color = Color.LightGray,
-                thickness = 1.dp,
-                modifier = Modifier.fillMaxWidth()
-            )
-        }
-
-        MeetingControlPanel(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(0.20f),
-            timeText = "00:00:00",
-            micEnabled = false,
-            micIcon = R.drawable.inactive_mic,
-            logoutIcon = R.drawable.inactive_logout,
-            powerIcon = R.drawable.inactive_power,
-            onFinish = onFinish,
-            onExitConfirmed = {},
-            viewModel = viewModel
-        )
-    }
-}
-
-@Composable
-private fun MeetingContent(
-    onFinish: (SilRokNavigation) -> Unit,
-    agendas: List<AgendaDto>,
-    checkedStates: List<Boolean>,
-    peekIndex: Int,
-    firstUncheckedIndex: Int,
-    viewModel: MeetingViewModel
-) {
-    Box(modifier = Modifier.fillMaxWidth()) {
-        val isLoading = agendas.isNullOrEmpty() || checkedStates.isNullOrEmpty() || peekIndex !in agendas.indices
-
-        if (isLoading) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize(),
-                contentAlignment = Alignment.Center
-            ) {
-                CircularProgressIndicator(color = Color(0xFF86CC3B))
-            }
-        } else {
-            Column(modifier = Modifier.fillMaxSize()) {
-                Box(modifier = Modifier.weight(0.2f))
-                Box(modifier = Modifier.weight(0.8f)) {
-                    Column(
-                        modifier = Modifier.fillMaxSize(),
-                        verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        Text(
-                            text = "회의가 시작되길\n기다리는 중",
-                            style = MaterialTheme.typography.titleLarge,
-                            textAlign = TextAlign.Center,
-                            color = Color.LightGray
-                        )
-                        StartButtonText { onFinish(SilRokNavigation.Meeting) }
-                    }
-                }
-            }
-
+        if (!isLoading && peekIndex in agendas.indices) {
             TopSheet(
                 collapsedHeight = 60.dp,
                 peekContent = {
@@ -186,7 +89,7 @@ private fun MeetingContent(
                         text = agendas[peekIndex].content,
                         checked = checkedStates[peekIndex],
                         isFocused = !checkedStates[peekIndex],
-                        onToggle = { viewModel.toggleAgendaChecked(peekIndex) }
+                        onToggle = { agendaViewModel.toggleAgendaChecked(peekIndex) }
                     )
                 },
                 content = {
@@ -196,30 +99,94 @@ private fun MeetingContent(
                                 text = item.content,
                                 checked = checkedStates[i],
                                 isFocused = !checkedStates[i] && firstUncheckedIndex == i,
-                                onToggle = { viewModel.toggleAgendaChecked(i) }
+                                onToggle = { agendaViewModel.toggleAgendaChecked(i) }
                             )
                         }
                     }
                 }
             )
         }
+
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth(),
+            contentAlignment = Alignment.Center
+        ) {
+            MeetingContent(
+                onFinish = onFinish,
+                isLoading = isLoading
+            )
+        }
+
+        Divider(
+            color = Color.LightGray,
+            thickness = 1.dp,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        MeetingControlPanel(
+            timeText = "00:00:00",
+            micEnabled = false,
+            micIcon = R.drawable.inactive_mic,
+            logoutIcon = R.drawable.inactive_logout,
+            powerIcon = R.drawable.inactive_power,
+            onFinish = onFinish,
+            onExitConfirmed = {},
+            viewModel = meetingViewModel
+        )
+    }
+}
+
+private fun isLoading(
+    peekIndex: Int,
+    agendas: List<*>,
+    checkedStates: List<*>
+): Boolean {
+    return agendas.isEmpty() || checkedStates.isEmpty() || peekIndex !in agendas.indices
+}
+
+@Composable
+private fun MeetingContent(
+    onFinish: (SilRokNavigation) -> Unit,
+    isLoading: Boolean
+) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        if (isLoading) {
+            CircularProgressIndicator(color = Color(0xFF86CC3B))
+        } else {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Text(
+                    text = "회의가 시작되길\n기다리는 중",
+                    style = MaterialTheme.typography.titleLarge,
+                    textAlign = TextAlign.Center,
+                    color = Color.LightGray
+                )
+
+                StartButton(onClick = { onFinish(SilRokNavigation.Meeting) })
+            }
+        }
     }
 }
 
 @Composable
-fun StartButtonText(onClick: () -> Unit) {
+fun StartButton(onClick: () -> Unit) {
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
-
     val baseColor = Color(0xFF1E93EF)
-    val pressedColor = baseColor.copy(alpha = 0.6f)
 
     Text(
         text = "시작하기",
         style = MaterialTheme.typography.titleLarge,
-        color = if (isPressed) pressedColor else baseColor,
+        color = if (isPressed) baseColor.copy(alpha = 0.6f) else baseColor,
         modifier = Modifier
-            .padding(top = 40.dp)
+            .padding(top = 36.dp)
             .clickable(
                 interactionSource = interactionSource,
                 indication = null,

--- a/app/src/main/java/com/imhungry/jjongseol/ui/meeting/MeetingWaitingScreen.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/meeting/MeetingWaitingScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -27,6 +28,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.imhungry.jjongseol.R
+import com.imhungry.jjongseol.data.model.agenda.AgendaDto
 import com.imhungry.jjongseol.ui.SilRokNavigation
 import com.imhungry.jjongseol.ui.component.CheckItem
 import com.imhungry.jjongseol.ui.component.CustomDialog
@@ -47,65 +49,33 @@ fun MeetingWaitingScreen(
     val errorMessage by meetingViewModel.errorMessage.collectAsState()
     val showDialog = remember { mutableStateOf(false) }
 
-    LaunchedEffect(Unit) {
+    // 아젠다 로딩 시작
+    LaunchedEffect(meetingId) {
+        agendaViewModel.onError = {
+            meetingViewModel.setErrorMessage(it)
+        }
         agendaViewModel.loadAgendas(meetingId)
-    }
-
-    if (errorMessage != null) {
-        showDialog.value = true
-    }
-
-    if (showDialog.value && errorMessage != null) {
-        CustomDialog(
-            description = if (errorMessage == "TOKEN_EXPIRED")
-                "로그인 정보가 만료되었어요. 다시 로그인해주세요."
-            else errorMessage,
-            confirmText = if (errorMessage == "TOKEN_EXPIRED") "로그인 하기" else "홈으로",
-            showDismissButton = false,
-            onDismissRequest = {},
-            onConfirmExit = {
-                showDialog.value = false
-                meetingViewModel.clearErrorMessage()
-                val destination = if (errorMessage == "TOKEN_EXPIRED") SilRokNavigation.Login else SilRokNavigation.Home
-                onFinish(destination)
-            }
-        )
     }
 
     val firstUncheckedIndex = checkedStates.indexOfFirst { !it }
     val peekIndex = if (firstUncheckedIndex == -1) checkedStates.lastIndex else firstUncheckedIndex
-    val isLoading = isLoading(peekIndex, agendas, checkedStates)
+    val isLoading = agendas.isEmpty() || checkedStates.isEmpty() || peekIndex !in agendas.indices
 
     Column(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
     ) {
-        if (!isLoading && peekIndex in agendas.indices) {
-            TopSheet(
-                collapsedHeight = 60.dp,
-                peekContent = {
-                    CheckItem(
-                        text = agendas[peekIndex].content,
-                        checked = checkedStates[peekIndex],
-                        isFocused = !checkedStates[peekIndex],
-                        onToggle = { agendaViewModel.toggleAgendaChecked(peekIndex) }
-                    )
-                },
-                content = {
-                    Column {
-                        agendas.forEachIndexed { i, item ->
-                            CheckItem(
-                                text = item.content,
-                                checked = checkedStates[i],
-                                isFocused = !checkedStates[i] && firstUncheckedIndex == i,
-                                onToggle = { agendaViewModel.toggleAgendaChecked(i) }
-                            )
-                        }
-                    }
-                }
-            )
-        }
+        ErrorDialogSection(errorMessage, showDialog, onFinish, meetingViewModel)
+
+        AgendaSection(
+            agendas = agendas,
+            checkedStates = checkedStates,
+            isLoading = isLoading,
+            peekIndex = peekIndex,
+            firstUncheckedIndex = firstUncheckedIndex,
+            onToggle = { agendaViewModel.toggleAgendaChecked(it) }
+        )
 
         Box(
             modifier = Modifier
@@ -113,10 +83,7 @@ fun MeetingWaitingScreen(
                 .fillMaxWidth(),
             contentAlignment = Alignment.Center
         ) {
-            MeetingContent(
-                onFinish = onFinish,
-                isLoading = isLoading
-            )
+            MeetingContentSection(isLoading = isLoading, onStart = { onFinish(SilRokNavigation.Meeting) })
         }
 
         Divider(
@@ -138,39 +105,88 @@ fun MeetingWaitingScreen(
     }
 }
 
-private fun isLoading(
-    peekIndex: Int,
-    agendas: List<*>,
-    checkedStates: List<*>
-): Boolean {
-    return agendas.isEmpty() || checkedStates.isEmpty() || peekIndex !in agendas.indices
+@Composable
+private fun ErrorDialogSection(
+    errorMessage: String?,
+    showDialog: MutableState<Boolean>,
+    onFinish: (SilRokNavigation) -> Unit,
+    meetingViewModel: MeetingViewModel
+) {
+    if (errorMessage != null) showDialog.value = true
+
+    if (showDialog.value && errorMessage != null) {
+        CustomDialog(
+            description = if (errorMessage == "TOKEN_EXPIRED")
+                "로그인 정보가 만료되었어요. 다시 로그인해주세요."
+            else errorMessage,
+            confirmText = if (errorMessage == "TOKEN_EXPIRED") "로그인 하기" else "홈으로",
+            showDismissButton = false,
+            onDismissRequest = {},
+            onConfirmExit = {
+                showDialog.value = false
+                meetingViewModel.clearErrorMessage()
+                val destination = if (errorMessage == "TOKEN_EXPIRED") SilRokNavigation.Login else SilRokNavigation.Home
+                onFinish(destination)
+            }
+        )
+    }
 }
 
 @Composable
-private fun MeetingContent(
-    onFinish: (SilRokNavigation) -> Unit,
-    isLoading: Boolean
+private fun AgendaSection(
+    agendas: List<AgendaDto>,
+    checkedStates: List<Boolean>,
+    isLoading: Boolean,
+    peekIndex: Int,
+    firstUncheckedIndex: Int,
+    onToggle: (Int) -> Unit
 ) {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
-    ) {
-        if (isLoading) {
-            CircularProgressIndicator(color = Color(0xFF86CC3B))
-        } else {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center
-            ) {
-                Text(
-                    text = "회의가 시작되길\n기다리는 중",
-                    style = MaterialTheme.typography.titleLarge,
-                    textAlign = TextAlign.Center,
-                    color = Color.LightGray
+    if (!isLoading && peekIndex in agendas.indices) {
+        TopSheet(
+            collapsedHeight = 60.dp,
+            peekContent = {
+                CheckItem(
+                    text = agendas[peekIndex].content,
+                    checked = checkedStates[peekIndex],
+                    isFocused = !checkedStates[peekIndex],
+                    onToggle = { onToggle(peekIndex) }
                 )
-
-                StartButton(onClick = { onFinish(SilRokNavigation.Meeting) })
+            },
+            content = {
+                Column {
+                    agendas.forEachIndexed { i, item ->
+                        CheckItem(
+                            text = item.content,
+                            checked = checkedStates[i],
+                            isFocused = !checkedStates[i] && firstUncheckedIndex == i,
+                            onToggle = { onToggle(i) }
+                        )
+                    }
+                }
             }
+        )
+    }
+}
+
+@Composable
+private fun MeetingContentSection(
+    isLoading: Boolean,
+    onStart: () -> Unit
+) {
+    if (isLoading) {
+        CircularProgressIndicator(color = Color(0xFF86CC3B))
+    } else {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "회의가 시작되길\n기다리는 중",
+                style = MaterialTheme.typography.titleLarge,
+                textAlign = TextAlign.Center,
+                color = Color.LightGray
+            )
+            StartButton(onClick = onStart)
         }
     }
 }
@@ -194,3 +210,4 @@ fun StartButton(onClick: () -> Unit) {
             )
     )
 }
+

--- a/app/src/main/java/com/imhungry/jjongseol/ui/meeting/bottom/MeetingControlPanel.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/meeting/bottom/MeetingControlPanel.kt
@@ -8,10 +8,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -46,28 +47,30 @@ fun MeetingControlPanel(
     var showDialog by remember { mutableStateOf(false) }
     var showLeaveDialog by remember { mutableStateOf(false) }
 
+    val iconColor = Color(0xFFB0B0B0)
+
     Column(
-        modifier = modifier.fillMaxWidth()
+        modifier = modifier
+            .fillMaxWidth()
+            .navigationBarsPadding()
+            .wrapContentHeight()
+            .padding(vertical = 20.dp, horizontal = 16.dp)
     ) {
         Box(
-            modifier = Modifier
-                .weight(0.35f)
-                .fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth(),
             contentAlignment = Alignment.Center
         ) {
             Text(
                 text = timeText,
                 fontSize = 24.sp,
-                color = Color(0xFFB0B0B0)
+                color = iconColor
             )
         }
 
         Row(
             modifier = Modifier
-                .weight(0.65f)
                 .fillMaxWidth()
-                .fillMaxHeight()
-                .padding(top = 8.dp)
+                .padding(top = 18.dp)
         ) {
             Spacer(modifier = Modifier.weight(1f))
 
@@ -75,94 +78,100 @@ fun MeetingControlPanel(
                 modifier = Modifier.weight(1f),
                 contentAlignment = Alignment.Center
             ) {
-                Image(
-                    painter = painterResource(
-                        id = if (micEnabled && isMicOn) R.drawable.mic else micIcon
-                    ),
-                    contentDescription = "마이크",
-                    modifier = Modifier
-                        .size(36.dp)
-                        .let { baseModifier ->
-                            if (micEnabled) {
-                                baseModifier.clickable(
-                                    interactionSource = remember { MutableInteractionSource() },
-                                    indication = null
-                                ) {
-                                    val newState = !isMicOn
-                                    isMicOn = newState
-                                    onMicToggle?.invoke(newState)
-                                }
-                            } else baseModifier
-                        }
+                ControlIcon(
+                    resId = if (micEnabled && isMicOn) R.drawable.mic else micIcon,
+                    description = "마이크",
+                    enabled = micEnabled,
+                    onClick = {
+                        isMicOn = !isMicOn
+                        onMicToggle?.invoke(isMicOn)
+                    }
                 )
             }
 
             Row(
-                modifier = Modifier
-                    .weight(1f)
-                    .padding(end = 16.dp),
+                modifier = Modifier.weight(1f),
                 horizontalArrangement = Arrangement.End
             ) {
-                Image(
-                    painter = painterResource(id = logoutIcon),
-                    contentDescription = "나가기",
-                    modifier = Modifier
-                        .size(36.dp)
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null
-                        ) {
-                            if (micEnabled) {
-                                showLeaveDialog = true
-                            }
-                        }
+                ControlIcon(
+                    resId = logoutIcon,
+                    description = "나가기",
+                    enabled = micEnabled,
+                    onClick = { showLeaveDialog = true }
                 )
 
                 Spacer(modifier = Modifier.size(12.dp))
 
-                Image(
-                    painter = painterResource(id = powerIcon),
-                    contentDescription = "종료",
-                    modifier = Modifier
-                        .size(36.dp)
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null
-                        ) {
-                            if (micEnabled) {
-                                showDialog = true
-                            }
-                        }
+                ControlIcon(
+                    resId = powerIcon,
+                    description = "종료",
+                    enabled = micEnabled,
+                    onClick = { showDialog = true }
                 )
             }
         }
     }
 
     if (showDialog) {
-        CustomDialog(
+        ExitDialog(
             description = "회의를 종료하시겠습니까?",
             confirmText = "종료",
-            dismissText = "취소",
-            onDismissRequest = { showDialog = false },
-            onConfirmExit = {
+            onConfirm = {
                 showDialog = false
                 onExitConfirmed()
                 onFinish(SilRokNavigation.MeetingEnd)
-            }
+            },
+            onDismiss = { showDialog = false }
         )
     }
 
     if (showLeaveDialog) {
-        CustomDialog(
+        ExitDialog(
             description = "회의에서 나가시겠습니까?",
             confirmText = "나가기",
-            dismissText = "취소",
-            onDismissRequest = { showLeaveDialog = false },
-            onConfirmExit = {
+            onConfirm = {
                 showLeaveDialog = false
                 viewModel.pauseEncoding()
                 onFinish(SilRokNavigation.Home)
-            }
+            },
+            onDismiss = { showLeaveDialog = false }
         )
     }
 }
+
+@Composable
+private fun ControlIcon(
+    resId: Int,
+    description: String,
+    enabled: Boolean,
+    onClick: () -> Unit
+) {
+    Image(
+        painter = painterResource(id = resId),
+        contentDescription = description,
+        modifier = Modifier
+            .size(36.dp)
+            .let { if (enabled) it.clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = onClick
+            ) else it }
+    )
+}
+
+@Composable
+private fun ExitDialog(
+    description: String,
+    confirmText: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    CustomDialog(
+        description = description,
+        confirmText = confirmText,
+        dismissText = "취소",
+        onConfirmExit = onConfirm,
+        onDismissRequest = onDismiss
+    )
+}
+

--- a/app/src/main/java/com/imhungry/jjongseol/ui/meeting/pager/MeetingRecordScreen.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/meeting/pager/MeetingRecordScreen.kt
@@ -1,10 +1,21 @@
 package com.imhungry.jjongseol.ui.meeting.pager
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -21,11 +32,13 @@ import com.imhungry.jjongseol.viewmodel.MeetingViewModel
 
 @Composable
 fun MeetingRecordScreen(
+    meetingViewModel: MeetingViewModel = hiltViewModel(),
     agendaViewModel: AgendaViewModel = hiltViewModel(),
     meetingId: Long
 ) {
     val agendas by agendaViewModel.agendaItems.collectAsState()
     val checkedStates by agendaViewModel.checkedStates.collectAsState()
+
 
     LaunchedEffect(meetingId) {
         agendaViewModel.loadAgendas(meetingId)

--- a/app/src/main/java/com/imhungry/jjongseol/ui/meeting/pager/MeetingRecordScreen.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/meeting/pager/MeetingRecordScreen.kt
@@ -16,18 +16,19 @@ import com.imhungry.jjongseol.ui.component.CheckItem
 import com.imhungry.jjongseol.ui.component.MeetingTerminationNotification
 import com.imhungry.jjongseol.ui.component.Notification
 import com.imhungry.jjongseol.ui.component.TopSheet
+import com.imhungry.jjongseol.viewmodel.AgendaViewModel
 import com.imhungry.jjongseol.viewmodel.MeetingViewModel
 
 @Composable
 fun MeetingRecordScreen(
-    viewModel: MeetingViewModel = hiltViewModel(),
+    agendaViewModel: AgendaViewModel = hiltViewModel(),
     meetingId: Long
 ) {
-    val agendas by viewModel.agendaItems.collectAsState()
-    val checkedStates by viewModel.checkedStates.collectAsState()
+    val agendas by agendaViewModel.agendaItems.collectAsState()
+    val checkedStates by agendaViewModel.checkedStates.collectAsState()
 
     LaunchedEffect(meetingId) {
-        viewModel.loadAgendas(meetingId)
+        agendaViewModel.loadAgendas(meetingId)
     }
 
     val lastCheckedIndex = remember { mutableStateOf(0) }
@@ -93,7 +94,7 @@ fun MeetingRecordScreen(
                             text = agendas[peekIndex].content,
                             checked = checkedStates[peekIndex],
                             isFocused = !checkedStates[peekIndex],
-                            onToggle = { viewModel.toggleAgendaChecked(peekIndex) }
+                            onToggle = { agendaViewModel.toggleAgendaChecked(peekIndex) }
                         )
                     },
                     content = {
@@ -103,7 +104,7 @@ fun MeetingRecordScreen(
                                     text = item.content,
                                     checked = checkedStates[i],
                                     isFocused = !checkedStates[i] && firstUncheckedIndex == i,
-                                    onToggle = { viewModel.toggleAgendaChecked(i) }
+                                    onToggle = { agendaViewModel.toggleAgendaChecked(i) }
                                 )
                             }
                         }

--- a/app/src/main/java/com/imhungry/jjongseol/viewmodel/AgendaViewModel.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/viewmodel/AgendaViewModel.kt
@@ -2,6 +2,7 @@ package com.imhungry.jjongseol.viewmodel
 
 import android.app.Application
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.imhungry.jjongseol.data.model.agenda.AgendaDto
@@ -15,8 +16,10 @@ import javax.inject.Inject
 @HiltViewModel
 class AgendaViewModel @Inject constructor(
     private val agendaRepository: AgendaRepository,
-    private val context: Application
+    private val context: Application,
 ) : AndroidViewModel(context) {
+
+    var onError: ((String) -> Unit)? = null
 
     private val _agendaItems = MutableStateFlow<List<AgendaDto>>(emptyList())
     val agendaItems: StateFlow<List<AgendaDto>> = _agendaItems
@@ -27,13 +30,16 @@ class AgendaViewModel @Inject constructor(
     private var loadedMeetingId: Long? = null
 
     fun loadAgendas(meetingId: Long) {
-        if (loadedMeetingId == meetingId && _agendaItems.value.isNotEmpty()) return
-
         viewModelScope.launch {
-            val agendas = agendaRepository.getAgendas(meetingId)
-            _agendaItems.value = agendas
-            _checkedStates.value = loadCheckedStatesFromPrefs(meetingId, agendas)
-            loadedMeetingId = meetingId
+            try {
+                val agendas = agendaRepository.getAgendas(meetingId)
+                _agendaItems.value = agendas
+                _checkedStates.value = loadCheckedStatesFromPrefs(meetingId, agendas)
+                loadedMeetingId = meetingId
+            } catch (e: Exception) {
+                Log.e("Agenda", "아젠다 로딩 실패", e)
+                onError?.invoke("아젠다 로딩 실패: ${e.message}")
+            }
         }
     }
 

--- a/app/src/main/java/com/imhungry/jjongseol/viewmodel/AgendaViewModel.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/viewmodel/AgendaViewModel.kt
@@ -2,15 +2,17 @@ package com.imhungry.jjongseol.viewmodel
 
 import android.app.Application
 import android.content.Context
-import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.imhungry.jjongseol.data.model.agenda.AgendaDto
+import com.imhungry.jjongseol.data.model.error.ApiError
 import com.imhungry.jjongseol.data.repository.AgendaRepository
+import com.imhungry.jjongseol.util.handleHttpException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import retrofit2.HttpException
 import javax.inject.Inject
 
 @HiltViewModel
@@ -19,7 +21,7 @@ class AgendaViewModel @Inject constructor(
     private val context: Application,
 ) : AndroidViewModel(context) {
 
-    var onError: ((String) -> Unit)? = null
+    var onError: ((ApiError) -> Unit)? = null
 
     private val _agendaItems = MutableStateFlow<List<AgendaDto>>(emptyList())
     val agendaItems: StateFlow<List<AgendaDto>> = _agendaItems
@@ -36,10 +38,13 @@ class AgendaViewModel @Inject constructor(
                 _agendaItems.value = agendas
                 _checkedStates.value = loadCheckedStatesFromPrefs(meetingId, agendas)
                 loadedMeetingId = meetingId
+            } catch (e: HttpException) {
+                val apiError = handleHttpException(e)
+                onError?.invoke(apiError)
             } catch (e: Exception) {
-                Log.e("Agenda", "아젠다 로딩 실패", e)
-                onError?.invoke("아젠다 로딩 실패: ${e.message}")
+                onError?.invoke(ApiError(message = e.message, errorId = null))
             }
+
         }
     }
 

--- a/app/src/main/java/com/imhungry/jjongseol/viewmodel/AgendaViewModel.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/viewmodel/AgendaViewModel.kt
@@ -1,0 +1,61 @@
+package com.imhungry.jjongseol.viewmodel
+
+import android.app.Application
+import android.content.Context
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.imhungry.jjongseol.data.model.agenda.AgendaDto
+import com.imhungry.jjongseol.data.repository.AgendaRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class AgendaViewModel @Inject constructor(
+    private val agendaRepository: AgendaRepository,
+    private val context: Application
+) : AndroidViewModel(context) {
+
+    private val _agendaItems = MutableStateFlow<List<AgendaDto>>(emptyList())
+    val agendaItems: StateFlow<List<AgendaDto>> = _agendaItems
+
+    private val _checkedStates = MutableStateFlow<List<Boolean>>(emptyList())
+    val checkedStates: StateFlow<List<Boolean>> = _checkedStates
+
+    private var loadedMeetingId: Long? = null
+
+    fun loadAgendas(meetingId: Long) {
+        if (loadedMeetingId == meetingId && _agendaItems.value.isNotEmpty()) return
+
+        viewModelScope.launch {
+            val agendas = agendaRepository.getAgendas(meetingId)
+            _agendaItems.value = agendas
+            _checkedStates.value = loadCheckedStatesFromPrefs(meetingId, agendas)
+            loadedMeetingId = meetingId
+        }
+    }
+
+    fun toggleAgendaChecked(index: Int) {
+        _checkedStates.value = _checkedStates.value.toMutableList().apply {
+            this[index] = !this[index]
+        }
+        saveCheckedStatesToPrefs()
+    }
+
+    private fun loadCheckedStatesFromPrefs(meetingId: Long, agendas: List<AgendaDto>): List<Boolean> {
+        val saved = context.getSharedPreferences("meeting_prefs", Context.MODE_PRIVATE)
+            .getString("checked_states_$meetingId", null)
+        return saved?.split(",")?.map { it.toBooleanStrictOrNull() ?: false }
+            ?.takeIf { it.size == agendas.size }
+            ?: agendas.map { it.isCompleted }
+    }
+
+    private fun saveCheckedStatesToPrefs() {
+        val states = _checkedStates.value.joinToString(",") { it.toString() }
+        context.getSharedPreferences("meeting_prefs", Context.MODE_PRIVATE).edit()
+            .putString("checked_states_${loadedMeetingId ?: -1}", states)
+            .apply()
+    }
+}

--- a/app/src/main/java/com/imhungry/jjongseol/viewmodel/MeetingViewModel.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/viewmodel/MeetingViewModel.kt
@@ -5,14 +5,17 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.imhungry.jjongseol.controller.StreamingController
 import com.imhungry.jjongseol.controller.TestDataSender
+import com.imhungry.jjongseol.data.model.MeetingReq
 import com.imhungry.jjongseol.data.model.error.ApiError
 import com.imhungry.jjongseol.data.model.feedback.FeedbackItem
 import com.imhungry.jjongseol.data.model.meeting.SummaryItem
+import com.imhungry.jjongseol.data.network.MeetingApi
 import com.imhungry.jjongseol.data.network.SseClient
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -20,7 +23,8 @@ class MeetingViewModel @Inject constructor(
     application: Application,
     private val sseClient: SseClient,
     private val streamingController: StreamingController,
-    private val testDataSender: TestDataSender
+    private val testDataSender: TestDataSender,
+    private val meetingApi: MeetingApi
 ) : AndroidViewModel(application) {
 
     private val _errorMessage = MutableStateFlow<String?>(null)
@@ -35,6 +39,26 @@ class MeetingViewModel @Inject constructor(
 
     fun clearErrorMessage() {
         _errorMessage.value = null
+    }
+
+    //새 회의 생성
+    fun createMeeting(
+        meetingReq: MeetingReq,
+        onSuccess: () -> Unit,
+        onError: (String) -> Unit
+    ) {
+        viewModelScope.launch {
+            try {
+                val response = meetingApi.createMeeting(meetingReq)
+                if (response.isSuccessful) {
+                    onSuccess()
+                } else {
+                    onError("에러 발생: ${response.code()} - ${response.errorBody()?.string()}")
+                }
+            } catch (e: Exception) {
+                onError("예외 발생: ${e.message}")
+            }
+        }
     }
 
     fun startStreamingService() = streamingController.startStreamingService()

--- a/app/src/main/java/com/imhungry/jjongseol/viewmodel/MeetingViewModel.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/viewmodel/MeetingViewModel.kt
@@ -37,6 +37,10 @@ class MeetingViewModel @Inject constructor(
     private val _errorMessage = MutableStateFlow<String?>(null)
     val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
 
+    fun setErrorMessage(message: String) {
+        _errorMessage.value = message
+    }
+
     fun clearErrorMessage() {
         _errorMessage.value = null
     }

--- a/app/src/main/java/com/imhungry/jjongseol/viewmodel/MeetingViewModel.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/viewmodel/MeetingViewModel.kt
@@ -6,16 +6,13 @@ import android.content.Intent
 import android.os.Build
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
-import com.imhungry.jjongseol.data.model.agenda.AgendaDto
 import com.imhungry.jjongseol.data.model.feedback.FeedbackItem
 import com.imhungry.jjongseol.data.model.meeting.SummaryItem
 import com.imhungry.jjongseol.data.network.FeedbackApi
 import com.imhungry.jjongseol.data.network.ParticipationRateApi
 import com.imhungry.jjongseol.data.network.SseClient
 import com.imhungry.jjongseol.data.network.SummaryApi
-import com.imhungry.jjongseol.data.repository.AgendaRepository
 import com.imhungry.jjongseol.service.AudioStreamingService
-import com.imhungry.jjongseol.util.handleHttpException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -24,13 +21,11 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import retrofit2.HttpException
 import javax.inject.Inject
 
 @HiltViewModel
 class MeetingViewModel @Inject constructor(
     application: Application,
-    private val agendaRepository: AgendaRepository,
     private val sseClient: SseClient,
     private val summaryApi: SummaryApi,
     private val participationRateApi: ParticipationRateApi,
@@ -39,7 +34,14 @@ class MeetingViewModel @Inject constructor(
 
     private val context by lazy { application.applicationContext }
 
-    // 음성 Streaming control
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
+
+    fun clearErrorMessage() {
+        _errorMessage.value = null
+    }
+
+    // 음성 스트리밍
     fun pauseEncoding() = AudioStreamingService.pauseEncoding()
     fun resumeEncoding() = AudioStreamingService.resumeEncoding()
 
@@ -67,65 +69,15 @@ class MeetingViewModel @Inject constructor(
         context.stopService(Intent(context, AudioStreamingService::class.java))
     }
 
-    // 아젠다 state
-    private val _agendaItems = MutableStateFlow<List<AgendaDto>>(emptyList())
-    val agendaItems: StateFlow<List<AgendaDto>> = _agendaItems
-
-    private var loadedMeetingId: Long? = null
-
-    private val _checkedStates = MutableStateFlow<List<Boolean>>(emptyList())
-    val checkedStates: StateFlow<List<Boolean>> = _checkedStates
-
-    val _errorMessage = MutableStateFlow<String?>(null)
-    val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
-
-    fun loadAgendas(meetingId: Long) {
-        if (loadedMeetingId == meetingId && _agendaItems.value.isNotEmpty()) return
-
-        viewModelScope.launch {
-            try {
-                val agendas = agendaRepository.getAgendas(meetingId)
-                _agendaItems.value = agendas
-                val savedStates = loadCheckedStatesFromPrefs(meetingId)
-                _checkedStates.value = if (savedStates.size == agendas.size) savedStates else agendas.map { it.isCompleted }
-                loadedMeetingId = meetingId
-            } catch (e: HttpException) {
-                val error = handleHttpException(e)
-                _errorMessage.value = if (e.code() == 401) "TOKEN_EXPIRED" else error.message
-            } catch (e: Exception) {
-                _errorMessage.value = "알 수 없는 오류가 발생했습니다."
-            }
-        }
-    }
-
-    private fun loadCheckedStatesFromPrefs(meetingId: Long): List<Boolean> {
-        val saved = context.getSharedPreferences("meeting_prefs", Context.MODE_PRIVATE)
-            .getString("checked_states_$meetingId", null)
-        return saved?.split(",")?.map { it.toBooleanStrictOrNull() ?: false } ?: emptyList()
-    }
-
-    fun toggleAgendaChecked(index: Int) {
-        val updated = _checkedStates.value.toMutableList().apply {
-            this[index] = !this[index]
-        }
-        _checkedStates.value = updated
-        saveCheckedStatesToPrefs()
-    }
-
-    private fun saveCheckedStatesToPrefs() {
-        val states = _checkedStates.value.joinToString(",") { it.toString() }
-        context.getSharedPreferences("meeting_prefs", Context.MODE_PRIVATE).edit()
-            .putString("checked_states_${loadedMeetingId ?: -1}", states)
-            .apply()
-    }
-
-    fun clearErrorMessage() {
-        _errorMessage.value = null
-    }
-
-    // Summary SSE
+    // SSE 수신
     private val _summaryList = MutableStateFlow<List<SummaryItem>>(emptyList())
     val summaryList: StateFlow<List<SummaryItem>> = _summaryList.asStateFlow()
+
+    private val _participationRate = MutableStateFlow<String?>(null)
+    val participationRate: StateFlow<String?> = _participationRate.asStateFlow()
+
+    private val _feedbackList = MutableStateFlow<List<FeedbackItem>>(emptyList())
+    val feedbackList: StateFlow<List<FeedbackItem>> = _feedbackList.asStateFlow()
 
     fun subscribeToSummary(meetingId: Long, timeProvider: () -> String) {
         sseClient.subscribeToSummary(
@@ -139,10 +91,6 @@ class MeetingViewModel @Inject constructor(
         )
     }
 
-    // Participation SSE
-    private val _participationRate = MutableStateFlow<String?>(null)
-    val participationRate: StateFlow<String?> = _participationRate.asStateFlow()
-
     fun subscribeToParticipationRate(meetingId: Long) {
         sseClient.subscribeToParticipationRate(
             meetingId,
@@ -154,10 +102,6 @@ class MeetingViewModel @Inject constructor(
             }
         )
     }
-
-    // Feedback SSE
-    private val _feedbackList = MutableStateFlow<List<FeedbackItem>>(emptyList())
-    val feedbackList: StateFlow<List<FeedbackItem>> = _feedbackList.asStateFlow()
 
     fun subscribeToFeedback(meetingId: Long, timeProvider: () -> String) {
         sseClient.subscribeToFeedback(
@@ -171,7 +115,11 @@ class MeetingViewModel @Inject constructor(
         )
     }
 
-    // Test send jobs
+    fun stopSse() {
+        sseClient.disconnect()
+    }
+
+    // 테스트 데이터 전송
     private var summaryTestJob: Job? = null
     private var participationTestJob: Job? = null
     private var feedbackTestJob: Job? = null
@@ -231,9 +179,5 @@ class MeetingViewModel @Inject constructor(
     fun stopSendingTestFeedback() {
         feedbackTestJob?.cancel()
         feedbackTestJob = null
-    }
-
-    fun stopSse() {
-        sseClient.disconnect()
     }
 }

--- a/app/src/main/java/com/imhungry/jjongseol/viewmodel/MeetingViewModel.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/viewmodel/MeetingViewModel.kt
@@ -1,38 +1,26 @@
 package com.imhungry.jjongseol.viewmodel
 
 import android.app.Application
-import android.content.Context
-import android.content.Intent
-import android.os.Build
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.imhungry.jjongseol.controller.StreamingController
+import com.imhungry.jjongseol.controller.TestDataSender
 import com.imhungry.jjongseol.data.model.feedback.FeedbackItem
 import com.imhungry.jjongseol.data.model.meeting.SummaryItem
-import com.imhungry.jjongseol.data.network.FeedbackApi
-import com.imhungry.jjongseol.data.network.ParticipationRateApi
 import com.imhungry.jjongseol.data.network.SseClient
-import com.imhungry.jjongseol.data.network.SummaryApi
-import com.imhungry.jjongseol.service.AudioStreamingService
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class MeetingViewModel @Inject constructor(
     application: Application,
     private val sseClient: SseClient,
-    private val summaryApi: SummaryApi,
-    private val participationRateApi: ParticipationRateApi,
-    private val feedbackApi: FeedbackApi
+    private val streamingController: StreamingController,
+    private val testDataSender: TestDataSender
 ) : AndroidViewModel(application) {
-
-    private val context by lazy { application.applicationContext }
 
     private val _errorMessage = MutableStateFlow<String?>(null)
     val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
@@ -45,35 +33,11 @@ class MeetingViewModel @Inject constructor(
         _errorMessage.value = null
     }
 
-    // 음성 스트리밍
-    fun pauseEncoding() = AudioStreamingService.pauseEncoding()
-    fun resumeEncoding() = AudioStreamingService.resumeEncoding()
+    fun startStreamingService() = streamingController.startStreamingService()
+    fun stopStreamingService() = streamingController.stopStreamingService()
+    fun pauseEncoding() = streamingController.pauseEncoding()
+    fun resumeEncoding() = streamingController.resumeEncoding()
 
-    fun startStreamingService() {
-        val prefs = context.getSharedPreferences("meeting_prefs", Context.MODE_PRIVATE)
-        if (!prefs.contains("meetingStartedAt")) {
-            prefs.edit()
-                .putBoolean("isMeetingOngoing", true)
-                .putLong("meetingStartedAt", System.currentTimeMillis())
-                .apply()
-        }
-
-        val intent = Intent(context, AudioStreamingService::class.java)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-            context.startForegroundService(intent)
-        else
-            context.startService(intent)
-    }
-
-    fun stopStreamingService() {
-        context.getSharedPreferences("meeting_prefs", Context.MODE_PRIVATE).edit()
-            .putBoolean("isMeetingOngoing", false)
-            .remove("meetingStartedAt")
-            .apply()
-        context.stopService(Intent(context, AudioStreamingService::class.java))
-    }
-
-    // SSE 수신
     private val _summaryList = MutableStateFlow<List<SummaryItem>>(emptyList())
     val summaryList: StateFlow<List<SummaryItem>> = _summaryList.asStateFlow()
 
@@ -123,65 +87,15 @@ class MeetingViewModel @Inject constructor(
         sseClient.disconnect()
     }
 
-    // 테스트 데이터 전송
-    private var summaryTestJob: Job? = null
-    private var participationTestJob: Job? = null
-    private var feedbackTestJob: Job? = null
-
-    fun startSendingTestSummary(meetingId: Long) {
-        if (summaryTestJob?.isActive == true) return
-        summaryTestJob = viewModelScope.launch {
-            while (isActive) {
-                try {
-                    summaryApi.sendTestSummary(meetingId)
-                } catch (e: Exception) {
-                    println("요약 전송 실패: ${e.message}")
-                }
-                delay(5000)
-            }
-        }
+    fun startSendingTestData(meetingId: Long) {
+        testDataSender.startSummary(meetingId, viewModelScope)
+        testDataSender.startParticipation(meetingId, viewModelScope)
+        testDataSender.startFeedback(meetingId, viewModelScope)
     }
 
-    fun stopSendingTestSummary() {
-        summaryTestJob?.cancel()
-        summaryTestJob = null
-    }
-
-    fun startSendingTestParticipationRate(meetingId: Long) {
-        if (participationTestJob?.isActive == true) return
-        participationTestJob = viewModelScope.launch {
-            while (isActive) {
-                try {
-                    participationRateApi.sendTestParticipationRate(meetingId)
-                } catch (e: Exception) {
-                    println("점유율 전송 실패: ${e.message}")
-                }
-                delay(5000)
-            }
-        }
-    }
-
-    fun stopSendingTestParticipationRate() {
-        participationTestJob?.cancel()
-        participationTestJob = null
-    }
-
-    fun startSendingTestFeedback(meetingId: Long) {
-        if (feedbackTestJob?.isActive == true) return
-        feedbackTestJob = viewModelScope.launch {
-            while (isActive) {
-                try {
-                    feedbackApi.sendTestFeedback(meetingId)
-                } catch (e: Exception) {
-                    println("피드백 전송 실패: ${e.message}")
-                }
-                delay(5000)
-            }
-        }
-    }
-
-    fun stopSendingTestFeedback() {
-        feedbackTestJob?.cancel()
-        feedbackTestJob = null
+    fun stopSendingTestData() {
+        testDataSender.stopSummary()
+        testDataSender.stopParticipation()
+        testDataSender.stopFeedback()
     }
 }

--- a/app/src/main/java/com/imhungry/jjongseol/viewmodel/MeetingViewModel.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/viewmodel/MeetingViewModel.kt
@@ -69,12 +69,12 @@ class MeetingViewModel @Inject constructor(
 
     // 아젠다 state
     private val _agendaItems = MutableStateFlow<List<AgendaDto>>(emptyList())
-    val agendaItems: StateFlow<List<AgendaDto>> = _agendaItems.asStateFlow()
+    val agendaItems: StateFlow<List<AgendaDto>> = _agendaItems
 
     private var loadedMeetingId: Long? = null
 
     private val _checkedStates = MutableStateFlow<List<Boolean>>(emptyList())
-    val checkedStates: StateFlow<List<Boolean>> = _checkedStates.asStateFlow()
+    val checkedStates: StateFlow<List<Boolean>> = _checkedStates
 
     val _errorMessage = MutableStateFlow<String?>(null)
     val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()

--- a/app/src/main/java/com/imhungry/jjongseol/viewmodel/MeetingViewModel.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/viewmodel/MeetingViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.imhungry.jjongseol.controller.StreamingController
 import com.imhungry.jjongseol.controller.TestDataSender
+import com.imhungry.jjongseol.data.model.error.ApiError
 import com.imhungry.jjongseol.data.model.feedback.FeedbackItem
 import com.imhungry.jjongseol.data.model.meeting.SummaryItem
 import com.imhungry.jjongseol.data.network.SseClient
@@ -25,8 +26,11 @@ class MeetingViewModel @Inject constructor(
     private val _errorMessage = MutableStateFlow<String?>(null)
     val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
 
-    fun setErrorMessage(message: String) {
-        _errorMessage.value = message
+    fun setError(apiError: ApiError) {
+        _errorMessage.value = when (apiError.message) {
+            "만료된 토큰입니다." -> "TOKEN_EXPIRED"
+            else -> apiError.message ?: "알 수 없는 오류 발생"
+        }
     }
 
     fun clearErrorMessage() {


### PR DESCRIPTION
1. MeetingViewModel 책임 분리
 - 아젠다 관련 로직 -> AgendaViewModel
 - 음성 스트리밍 및 테스트 데이터 전송 -> StreamingController, TestDataSender
2.  UI 구조 개선 
 - MeetingWaitingScreen과 MeetingScreen 레이아웃 수정
 - Agenda 로딩 상태를 기준으로 MeetingInitController 동작 타이밍 조정
3. 로그인 토큰 만료 시 로그인 화면으로 이동하도록 처리