### PR TITLE
feat: 회의 생성 페이지 완료 및 홈 화면, 캘린더에 회의 정보 추가

### DIFF
--- a/app/src/main/java/com/imhungry/jjongseol/data/model/home/MeetingListResponse.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/data/model/home/MeetingListResponse.kt
@@ -1,0 +1,10 @@
+package com.imhungry.jjongseol.data.model.home
+
+data class MeetingListWrapper(
+    val message: String,
+    val data: MeetingListData
+)
+
+data class MeetingListData(
+    val meetings: List<MeetingResponse>
+)

--- a/app/src/main/java/com/imhungry/jjongseol/data/model/home/MeetingResponse.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/data/model/home/MeetingResponse.kt
@@ -1,0 +1,17 @@
+package com.imhungry.jjongseol.data.model.home
+
+import com.imhungry.jjongseol.ui.home.meetingdata.MeetingInfo
+import java.time.LocalDateTime
+
+data class MeetingResponse(
+    val title: String,
+    val scheduledStartTime: String,
+    val targetTime: Int,
+    val status: String
+)
+
+fun MeetingResponse.toMeetingInfo(): MeetingInfo {
+    val start = LocalDateTime.parse(scheduledStartTime)
+    val end = start.plusMinutes(targetTime.toLong())
+    return MeetingInfo(title, start, end)
+}

--- a/app/src/main/java/com/imhungry/jjongseol/data/model/meeting/MeetingReq.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/data/model/meeting/MeetingReq.kt
@@ -6,6 +6,7 @@ data class MeetingReq(
     val location: String,
     val targetTime: Int,
     val restInterval: Int,
+    val restDuration: Int,
     val scheduledStartTime: String,
     val agendas: List<String>,
     val participants: List<String>

--- a/app/src/main/java/com/imhungry/jjongseol/data/model/user/UserData.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/data/model/user/UserData.kt
@@ -1,0 +1,6 @@
+package com.imhungry.jjongseol.data.model.user
+
+data class UserData(
+    val email: String,
+    val nickname: String
+)

--- a/app/src/main/java/com/imhungry/jjongseol/data/model/user/UserDto.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/data/model/user/UserDto.kt
@@ -1,6 +1,6 @@
 package com.imhungry.jjongseol.data.model.user
 
 data class UserDto(
-    val email: String,
-    val name: String
+    val message: String,
+    val data: UserData
 )

--- a/app/src/main/java/com/imhungry/jjongseol/data/network/api/MeetingApi.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/data/network/api/MeetingApi.kt
@@ -1,11 +1,20 @@
 package com.imhungry.jjongseol.data.network.api
 
+import com.imhungry.jjongseol.data.model.home.MeetingListWrapper
 import com.imhungry.jjongseol.data.model.meeting.MeetingReq
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Query
 
 interface MeetingApi {
     @POST("api/meetings")
     suspend fun createMeeting(@Body request: MeetingReq): Response<Unit>
+
+    @GET("api/meetings")
+    suspend fun getMeetings(
+        @Query("year") year: Int,
+        @Query("month") month: Int
+    ): Response<MeetingListWrapper>
 }

--- a/app/src/main/java/com/imhungry/jjongseol/ui/home/Calendar.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/home/Calendar.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -39,44 +40,28 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.imhungry.jjongseol.R
-import com.imhungry.jjongseol.ui.home.meetingdata.ScheduleItem
+import com.imhungry.jjongseol.data.model.home.MeetingResponse
 import com.imhungry.jjongseol.ui.theme.md_theme_button_color_blue
+import com.imhungry.jjongseol.viewmodel.ScheduleViewModel
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
 
-val schedules = listOf(
-    ScheduleItem("회의 1", "13:00", "2025.04.26"),
-    ScheduleItem("회의 2", "15:00", "2025.04.26"),
-    ScheduleItem("회의 1", "13:00", "2025.04.26"),
-    ScheduleItem("회의 2", "15:00", "2025.04.26"),
-    ScheduleItem("회의 1", "13:00", "2025.04.26"),
-    ScheduleItem("회의 2", "15:00", "2025.04.26"),
-    ScheduleItem("회의 1", "13:00", "2025.04.26"),
-    ScheduleItem("회의 2", "15:00", "2025.04.26"),
-    ScheduleItem("회의 1", "13:00", "2025.04.26"),
-    ScheduleItem("회의 2", "15:00", "2025.04.26"),
-    ScheduleItem("워크샵", "11:00", "2025.04.26"),
-    ScheduleItem("고객 미팅", "14:00", "2025.04.27"),
-    ScheduleItem("프로젝트 리뷰", "16:00", "2025.06.28"),
-    ScheduleItem("웹 세미나", "10:00", "2025.07.01"),
-    ScheduleItem("팀 런치", "12:00", "2025.07.01"),
-    ScheduleItem("제품 발표회", "15:00", "2025.07.02"),
-    ScheduleItem("경영진 회의", "09:00", "2025.07.03"),
-    ScheduleItem("기술 트레이닝", "13:30", "2025.07.03"),
-    ScheduleItem("마케팅 전략 논의", "11:00", "2025.07.04"),
-    ScheduleItem("영업 팀 회의", "15:00", "2025.07.04"),
-    ScheduleItem("개발자 컨퍼런스", "10:00", "2025.07.05"),
-    ScheduleItem("재무 검토 회의", "14:00", "2025.07.05")
-)
-
 @Composable
-fun CalendarScreen(navController: NavController) {
+fun CalendarScreen(navController: NavController, viewModel: ScheduleViewModel = hiltViewModel()) {
     var currentYearMonth by remember { mutableStateOf(YearMonth.now()) }
     var selectedDate by remember { mutableStateOf(LocalDate.now()) }
     var showNumberPicker by remember { mutableStateOf(false) }
+    val meetings by viewModel.meetings
+
+    LaunchedEffect(currentYearMonth) {
+        viewModel.loadMeetings(currentYearMonth)
+    }
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -105,7 +90,7 @@ fun CalendarScreen(navController: NavController) {
             yearMonth = currentYearMonth,
             selectedDate = selectedDate,
             onDateSelected = { selectedDate = it },
-            schedules = schedules
+            meetings = meetings
         )
     }
 
@@ -130,12 +115,17 @@ fun CalendarScreen(navController: NavController) {
         modifier = Modifier.padding(top = 30.dp,bottom = 10.dp)
     )
 
-    val handleScheduleClick = { schedule: ScheduleItem ->
+    val handleScheduleClick = { schedule: MeetingResponse ->
         //navController.navigate("completeProfile")
     }
 
-    DailyScheduleView(selectedDate.format(DateTimeFormatter.ofPattern("yyyy.MM.dd")),
-        schedules, handleScheduleClick)
+    val selectedDateStr = selectedDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+
+    DailyScheduleView(
+        selectedDate = selectedDateStr,
+        schedules = meetings,
+        onScheduleClick = handleScheduleClick
+    )
 
 }
 
@@ -194,14 +184,16 @@ fun CalendarHeader(
         )
     }
 }
+
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun CalendarGrid(
     yearMonth: YearMonth,
     selectedDate: LocalDate,
     onDateSelected: (LocalDate) -> Unit,
-    schedules: List<ScheduleItem>
+    meetings: List<MeetingResponse>
 ) {
+    val today = LocalDate.now()
     val firstDayOfMonth = yearMonth.atDay(1)
     val daysInMonth = yearMonth.lengthOfMonth()
     val firstDayOfWeek = firstDayOfMonth.dayOfWeek.value % 7
@@ -209,18 +201,12 @@ fun CalendarGrid(
 
     val dates = (0 until totalCells).map { index ->
         val dayOffset = index - firstDayOfWeek
-        val date = firstDayOfMonth.plusDays(dayOffset.toLong())
-        date
+        firstDayOfMonth.plusDays(dayOffset.toLong())
     }
 
-    val formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
-    val datesWithEvents = schedules
-        .filter { schedule ->
-            val scheduleDate = LocalDate.parse(schedule.date, formatter)
-            scheduleDate.month == yearMonth.month && scheduleDate.year == yearMonth.year
-        }
-        .map { LocalDate.parse(it.date, formatter) }
-        .toSet()
+    val scheduleMap = meetings.groupBy {
+        LocalDateTime.parse(it.scheduledStartTime).toLocalDate()
+    }
 
     Column {
         Row(Modifier.fillMaxWidth()) {
@@ -242,23 +228,38 @@ fun CalendarGrid(
                 week.forEach { date ->
                     val isCurrentMonth = date.month == yearMonth.month
                     val isSelected = date == selectedDate
-                    val dayOfWeek = date.dayOfWeek.value % 7
-                    val hasEvent = date in datesWithEvents
+                    val hasMeeting = scheduleMap.containsKey(date)
+                    val meetingsOnDate = scheduleMap[date].orEmpty()
+
+                    val hasCompleted = meetingsOnDate.any { it.status == "COMPLETED" }
+                    val hasWaiting = meetingsOnDate.any { it.status == "WAITING" }
+                    //진행중이거나 취소된 회의는 어떻게 표시할건지
+
+                    val backgroundColor = if (isSelected) {
+                        Color(0xFFDAF2FF)
+                    } else {
+                        Color.Transparent
+                    }
+
+                    //색상은 임시지정
+                    val textColor = when {
+                        //isSelected -> Color.Black
+                        date.isAfter(today) && hasMeeting -> Color.Yellow //미래 회의
+                        date.isBefore(today) && hasCompleted -> md_theme_button_color_blue //완료된 회의
+                        date.isBefore(today) && hasWaiting -> Color.Green //대기 중 회의
+                        isCurrentMonth && date.dayOfWeek.value % 7 == 0 -> Color.Red //일요일
+                        isCurrentMonth && date.dayOfWeek.value % 7 == 6 -> Color.Blue //토요일
+                        isCurrentMonth -> Color.Black //일반
+                        else -> Color.White
+                        //else -> Color.LightGray //다크 모드 하면 이걸로
+                    }
 
                     Box(
                         modifier = Modifier
                             .weight(1f)
                             .aspectRatio(1f)
                             .padding(2.dp)
-                            .background(
-                                when {
-                                    isSelected && isCurrentMonth && hasEvent -> Color(0xFFDAF2FF) //일정이 있고 선택된 날
-                                    isSelected && isCurrentMonth -> Color(0xFFDAF2FF) //선택된 날
-                                    !isCurrentMonth -> Color.White.copy(alpha = 0.3f)
-                                    else -> Color.Transparent
-                                },
-                                shape = RoundedCornerShape(100)
-                            )
+                            .background(backgroundColor, shape = RoundedCornerShape(100))
                             .clickable(
                                 interactionSource = remember { MutableInteractionSource() },
                                 indication = null
@@ -270,13 +271,7 @@ fun CalendarGrid(
                         Text(
                             text = date.dayOfMonth.toString(),
                             style = MaterialTheme.typography.bodyMedium,
-                            color = when {
-                                isSelected && hasEvent -> md_theme_button_color_blue //일정이 있고 선택된 날
-                                hasEvent -> md_theme_button_color_blue //일정만 있는 날
-                                isCurrentMonth && dayOfWeek == 0 -> Color.Red //일요일
-                                isCurrentMonth -> Color.Black //일반
-                                else -> Color.White
-                            }
+                            color = textColor
                         )
                     }
                 }
@@ -345,8 +340,8 @@ fun NumberPickerDialog(
 
 
 @Composable
-fun DailyScheduleView(selectedDate: String, schedules: List<ScheduleItem>, onScheduleClick: (ScheduleItem) -> Unit) {
-    val dailySchedules = schedules.filter { it.date == selectedDate }
+fun DailyScheduleView(selectedDate: String, schedules: List<MeetingResponse>, onScheduleClick: (MeetingResponse) -> Unit) {
+    val dailySchedules = schedules.filter { it.scheduledStartTime.startsWith(selectedDate) }
 
     if (dailySchedules.isEmpty()) {
         Text("일정이 없습니다", modifier = Modifier.fillMaxWidth().widthIn(100.dp).padding(top=20.dp), textAlign = TextAlign.Center)
@@ -371,7 +366,9 @@ fun DailyScheduleView(selectedDate: String, schedules: List<ScheduleItem>, onSch
                     )
                     Spacer(Modifier.weight(1f))
                     Text(
-                        text = schedule.time,
+                        text = LocalDateTime.parse(schedule.scheduledStartTime)
+                            .toLocalTime()
+                            .format(DateTimeFormatter.ofPattern("HH:mm")),
                         style = androidx.compose.material.MaterialTheme.typography.body1
                     )
                 }

--- a/app/src/main/java/com/imhungry/jjongseol/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/home/HomeScreen.kt
@@ -33,6 +33,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -50,9 +52,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.imhungry.jjongseol.R
 import com.imhungry.jjongseol.ui.theme.md_theme_button_color_blue
+import com.imhungry.jjongseol.viewmodel.MeetingViewModel
 import kotlinx.coroutines.launch
 
 
@@ -153,7 +157,15 @@ fun HomeScreen(navController: NavController) {
 
 @Composable
 fun MainHomeScreen(navController: NavController){
+    val viewModel: MeetingViewModel = hiltViewModel()
+    val meetings by viewModel.meetings.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.loadMeetings()
+    }
+
     var calendarToggle by remember { mutableStateOf(true) }
+
     ConstraintLayout (modifier = Modifier
         .background(Color.White)
         .fillMaxSize()){
@@ -223,7 +235,12 @@ fun MainHomeScreen(navController: NavController){
                     bottom.linkTo(parent.bottom)
                 }
         ) {
-            MeetingCard()
+            MeetingCardList(
+                meetings = meetings,
+                onJoinMeeting = { meeting ->
+                    //navController.navigate("meeting/${meeting.id}")
+                }
+            )
         }
 
         Box(
@@ -271,56 +288,6 @@ fun CreateNewMeetingButton(onClick: () -> Unit) {
                 )
             }
         )
-    }
-}
-
-@Composable
-fun MeetingCard() {
-    var isVisible by remember { mutableStateOf(true) }
-
-    if (isVisible) {
-        Card(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(20.dp)
-                .height(180.dp),
-            elevation = 2.dp
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(20.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center
-            ) {
-                Text(
-                    text = "현재 진행 중인 회의가 있어요!",
-                    color = Color.DarkGray,
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = "종설 회의",
-                    color = Color.DarkGray,
-                )
-                Text(
-                    text = "2025.04.01. 18:00~20:00",
-                    color = Color.DarkGray,
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    Text("참여하지 않기", Modifier.clickable{isVisible = false}
-                        .padding(10.dp),
-                        color = md_theme_button_color_blue)
-                    Spacer(Modifier.weight(1f))
-                    Text("바로 참여하기 >", Modifier.clickable {}
-                        .padding(10.dp),
-                        color = md_theme_button_color_blue)
-                }
-            }
-        }
     }
 }
 

--- a/app/src/main/java/com/imhungry/jjongseol/ui/home/MeetingCardScreen.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/home/MeetingCardScreen.kt
@@ -1,0 +1,93 @@
+package com.imhungry.jjongseol.ui.home
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.imhungry.jjongseol.data.model.home.MeetingResponse
+import com.imhungry.jjongseol.ui.theme.md_theme_button_color_blue
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+@Composable
+fun MeetingCardList(meetings: List<MeetingResponse>, onJoinMeeting: (MeetingResponse) -> Unit) {
+    val inProgressMeetings = remember(meetings) {
+        meetings.filter { it.status == "IN_PROGRESS" }
+    }
+    var currentIndex by remember { mutableStateOf(0) }
+
+    if (currentIndex < inProgressMeetings.size) {
+        MeetingCard(
+            meeting = inProgressMeetings[currentIndex],
+            onDismiss = { currentIndex++ },
+            onJoin = { onJoinMeeting(inProgressMeetings[currentIndex]) }
+        )
+    }
+}
+
+@Composable
+fun MeetingCard(
+    meeting: MeetingResponse,
+    onDismiss: () -> Unit,
+    onJoin: () -> Unit
+) {
+    val dateTime = LocalDateTime.parse(meeting.scheduledStartTime)
+    val timeText = "${dateTime.toLocalDate()} ${dateTime.toLocalTime().format(DateTimeFormatter.ofPattern("HH:mm"))}"
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(20.dp)
+            .height(180.dp),
+        elevation = 2.dp
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(text = "현재 진행 중인 회의가 있어요!", color = Color.DarkGray)
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(text = meeting.title, color = Color.DarkGray)
+            Text(text = "$timeText ~", color = Color.DarkGray)
+            Spacer(modifier = Modifier.height(16.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "참여하지 않기",
+                    modifier = Modifier
+                        .clickable { onDismiss() }
+                        .padding(10.dp),
+                    color = md_theme_button_color_blue
+                )
+                Spacer(Modifier.weight(1f))
+                Text(
+                    text = "바로 참여하기 >",
+                    modifier = Modifier
+                        .clickable { onJoin() }
+                        .padding(10.dp),
+                    color = md_theme_button_color_blue
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/imhungry/jjongseol/ui/home/MeetingRecord.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/home/MeetingRecord.kt
@@ -12,46 +12,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.imhungry.jjongseol.ui.home.meetingdata.MeetingRecord
+import com.imhungry.jjongseol.viewmodel.MeetingViewModel
 
 @Composable
-fun MeetingRecordsScreen() {
+fun MeetingRecordsScreen(viewModel: MeetingViewModel = hiltViewModel()) {
     var showDetails by remember { mutableStateOf(false) }
     var pagingIndex by remember { mutableStateOf(10) }
-    val meetingRecordList = listOf(
-        MeetingRecord("회의 1", "2025.1.2"),
-        MeetingRecord("회의 2", "2025.1.2"),
-        MeetingRecord("회의 3", "2026.1.2"),
-        MeetingRecord("회의 4", "2026.1.2"),
-        MeetingRecord("회의 1", "2022.1.2"),
-        MeetingRecord("회의 2", "2022.10.25"),
-        MeetingRecord("회의 3", "2022.11.20"),
-        MeetingRecord("회의 4", "2022.12.27"),
-        MeetingRecord("회의 5", "2023.1.2"),
-        MeetingRecord("회의 6", "2024.10.6"),
-        MeetingRecord("회의 1", "2022.1.2"),
-        MeetingRecord("회의 2", "2022.10.25"),
-        MeetingRecord("회의 3", "2022.11.20"),
-        MeetingRecord("회의 4", "2022.12.27"),
-        MeetingRecord("회의 5", "2023.1.2"),
-        MeetingRecord("회의 6", "2024.10.6"),
-        MeetingRecord("회의 1", "2025.1.2"),
-        MeetingRecord("회의 2", "2025.1.2"),
-        MeetingRecord("회의 3", "2026.1.2"),
-        MeetingRecord("회의 4", "2026.1.2"),
-        MeetingRecord("회의 1", "2022.1.2"),
-        MeetingRecord("회의 2", "2022.10.25"),
-        MeetingRecord("회의 3", "2022.11.20"),
-        MeetingRecord("회의 4", "2022.12.27"),
-        MeetingRecord("회의 5", "2023.1.2"),
-        MeetingRecord("회의 6", "2024.10.6"),
-        MeetingRecord("회의 1", "2022.1.2"),
-        MeetingRecord("회의 2", "2022.10.25"),
-        MeetingRecord("회의 3", "2022.11.20"),
-        MeetingRecord("회의 4", "2022.12.27"),
-        MeetingRecord("회의 5", "2023.1.2"),
-        MeetingRecord("회의 6", "2024.10.6")
-    )
+
+    val pastMeetings by viewModel.pastMeetings.collectAsState()
+    val currentList = pastMeetings.take(pagingIndex)
 
     Column(
         modifier = Modifier
@@ -68,26 +39,24 @@ fun MeetingRecordsScreen() {
             horizontalArrangement = Arrangement.SpaceBetween,
             modifier = Modifier.fillMaxWidth()
         ) {
-            Text(
-                text = "회의 기록",
-                style = MaterialTheme.typography.titleLarge
-            )
+            Text("지난 회의", style = MaterialTheme.typography.titleLarge)
             Icon(
                 imageVector = Icons.Filled.ArrowDropDown,
                 contentDescription = "토글 버튼",
                 modifier = Modifier
                     .size(30.dp)
-                    .graphicsLayer {
-                        rotationZ = if (showDetails) 0f else 270f
-                    }
+                    .graphicsLayer { rotationZ = if (showDetails) 0f else 270f }
             )
         }
+
         if (showDetails) {
-            val currentList = meetingRecordList.take(pagingIndex)
-            currentList.forEach { record ->
-                MeetingRecordButton(record)
+            currentList.forEach {
+                MeetingRecordButton(
+                    MeetingRecord(it.title, it.startDateTime.toLocalDate().toString())
+                )
             }
-            if (pagingIndex < meetingRecordList.size) {
+
+            if (pagingIndex < pastMeetings.size) {
                 Text(
                     text = "더보기",
                     style = MaterialTheme.typography.bodyLarge.copy(color = Color.Gray),
@@ -95,7 +64,7 @@ fun MeetingRecordsScreen() {
                         .fillMaxWidth()
                         .padding(vertical = 8.dp)
                         .clickable {
-                            pagingIndex = (pagingIndex + 10).coerceAtMost(meetingRecordList.size)
+                            pagingIndex = (pagingIndex + 10).coerceAtMost(pastMeetings.size)
                         }
                 )
             }

--- a/app/src/main/java/com/imhungry/jjongseol/ui/home/ScheduledMeeting.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/home/ScheduledMeeting.kt
@@ -12,71 +12,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.imhungry.jjongseol.ui.home.meetingdata.ScheduledMeeting
+import com.imhungry.jjongseol.viewmodel.MeetingViewModel
 
 @Composable
-fun ScheduledMeetingScreen() {
+fun ScheduledMeetingScreen(viewModel: MeetingViewModel = hiltViewModel()) {
     var showDetails by remember { mutableStateOf(false) }
     var pagingIndex by remember { mutableStateOf(10) }
-    val scheduledMeetingList = listOf(
-        ScheduledMeeting("회의 1", "2025.1.2"),
-        ScheduledMeeting("회의 2", "2025.1.2"),
-        ScheduledMeeting("회의 3", "2026.1.2"),
-        ScheduledMeeting("회의 4", "2026.1.2"),
-        ScheduledMeeting("회의 1", "2022.1.2"),
-        ScheduledMeeting("회의 2", "2022.10.25"),
-        ScheduledMeeting("회의 3", "2022.11.20"),
-        ScheduledMeeting("회의 4", "2022.12.27"),
-        ScheduledMeeting("회의 5", "2023.1.2"),
-        ScheduledMeeting("회의 6", "2024.10.6"),
-        ScheduledMeeting("회의 1", "2022.1.2"),
-        ScheduledMeeting("회의 2", "2022.10.25"),
-        ScheduledMeeting("회의 3", "2022.11.20"),
-        ScheduledMeeting("회의 4", "2022.12.27"),
-        ScheduledMeeting("회의 1", "2025.1.2"),
-        ScheduledMeeting("회의 2", "2025.1.2"),
-        ScheduledMeeting("회의 3", "2026.1.2"),
-        ScheduledMeeting("회의 4", "2026.1.2"),
-        ScheduledMeeting("회의 1", "2022.1.2"),
-        ScheduledMeeting("회의 2", "2022.10.25"),
-        ScheduledMeeting("회의 3", "2022.11.20"),
-        ScheduledMeeting("회의 4", "2022.12.27"),
-        ScheduledMeeting("회의 5", "2023.1.2"),
-        ScheduledMeeting("회의 6", "2024.10.6"),
-        ScheduledMeeting("회의 1", "2022.1.2"),
-        ScheduledMeeting("회의 2", "2022.10.25"),
-        ScheduledMeeting("회의 3", "2022.11.20"),
-        ScheduledMeeting("회의 4", "2022.12.27"),
-        ScheduledMeeting("회의 1", "2025.1.2"),
-        ScheduledMeeting("회의 2", "2025.1.2"),
-        ScheduledMeeting("회의 3", "2026.1.2"),
-        ScheduledMeeting("회의 4", "2026.1.2"),
-        ScheduledMeeting("회의 1", "2022.1.2"),
-        ScheduledMeeting("회의 2", "2022.10.25"),
-        ScheduledMeeting("회의 3", "2022.11.20"),
-        ScheduledMeeting("회의 4", "2022.12.27"),
-        ScheduledMeeting("회의 5", "2023.1.2"),
-        ScheduledMeeting("회의 6", "2024.10.6"),
-        ScheduledMeeting("회의 1", "2022.1.2"),
-        ScheduledMeeting("회의 2", "2022.10.25"),
-        ScheduledMeeting("회의 3", "2022.11.20"),
-        ScheduledMeeting("회의 4", "2022.12.27"),
-        ScheduledMeeting("회의 1", "2025.1.2"),
-        ScheduledMeeting("회의 2", "2025.1.2"),
-        ScheduledMeeting("회의 3", "2026.1.2"),
-        ScheduledMeeting("회의 4", "2026.1.2"),
-        ScheduledMeeting("회의 1", "2022.1.2"),
-        ScheduledMeeting("회의 2", "2022.10.25"),
-        ScheduledMeeting("회의 3", "2022.11.20"),
-        ScheduledMeeting("회의 4", "2022.12.27"),
-        ScheduledMeeting("회의 5", "2023.1.2"),
-        ScheduledMeeting("회의 6", "2024.10.6"),
-        ScheduledMeeting("회의 1", "2022.1.2"),
-        ScheduledMeeting("회의 2", "2022.10.25"),
-        ScheduledMeeting("회의 3", "2022.11.20"),
-        ScheduledMeeting("회의 4", "2022.12.27"),
 
-    )
+    val scheduledMeetings by viewModel.scheduledMeetings.collectAsState()
+
+    val currentList = scheduledMeetings.take(pagingIndex)
 
     Column(
         modifier = Modifier
@@ -93,26 +40,24 @@ fun ScheduledMeetingScreen() {
             horizontalArrangement = Arrangement.SpaceBetween,
             modifier = Modifier.fillMaxWidth()
         ) {
-            Text(
-                text = "예정된 회의",
-                style = MaterialTheme.typography.titleLarge
-            )
+            Text("예정된 회의", style = MaterialTheme.typography.titleLarge)
             Icon(
                 imageVector = Icons.Filled.ArrowDropDown,
                 contentDescription = "토글 버튼",
                 modifier = Modifier
                     .size(30.dp)
-                    .graphicsLayer {
-                        rotationZ = if (showDetails) 0f else 270f
-                    }
+                    .graphicsLayer { rotationZ = if (showDetails) 0f else 270f }
             )
         }
+
         if (showDetails) {
-            val currentList = scheduledMeetingList.take(pagingIndex)
-            currentList.forEach { record ->
-                ScheduledMeetingButton(record)
+            currentList.forEach {
+                ScheduledMeetingButton(
+                    ScheduledMeeting(it.title, it.startDateTime.toLocalDate().toString())
+                )
             }
-            if (pagingIndex < scheduledMeetingList.size) {
+
+            if (pagingIndex < scheduledMeetings.size) {
                 Text(
                     text = "더보기",
                     style = MaterialTheme.typography.bodyLarge.copy(color = Color.Gray),
@@ -120,7 +65,7 @@ fun ScheduledMeetingScreen() {
                         .fillMaxWidth()
                         .padding(vertical = 8.dp)
                         .clickable {
-                            pagingIndex = (pagingIndex + 10).coerceAtMost(scheduledMeetingList.size)
+                            pagingIndex = (pagingIndex + 10).coerceAtMost(scheduledMeetings.size)
                         }
                 )
             }

--- a/app/src/main/java/com/imhungry/jjongseol/ui/home/meetingdata/MeetingInfo.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/home/meetingdata/MeetingInfo.kt
@@ -1,0 +1,9 @@
+package com.imhungry.jjongseol.ui.home.meetingdata
+
+import java.time.LocalDateTime
+
+data class MeetingInfo(
+    val title: String,
+    val startDateTime: LocalDateTime,
+    val endDateTime: LocalDateTime
+)

--- a/app/src/main/java/com/imhungry/jjongseol/ui/home/meetingdata/ScheduleItem.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/home/meetingdata/ScheduleItem.kt
@@ -1,3 +1,8 @@
 package com.imhungry.jjongseol.ui.home.meetingdata
 
-data class ScheduleItem(val title: String, val time: String, val date: String)
+data class ScheduleItem(
+    val title: String,
+    val time: String,
+    val date: String,
+    val status: String
+)

--- a/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/CreateNewMeeting.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/CreateNewMeeting.kt
@@ -409,6 +409,7 @@ fun CreateNewMeetingScreen(navController: NavController){
                             location = place.value,
                             targetTime = durationInMinutes,
                             restInterval = breakTime.value.toIntOrNull() ?: 0,
+                            restDuration = breakTimeMinute.value.toIntOrNull() ?: 0,
                             scheduledStartTime = scheduledStartTime.toString(),
                             agendas = agendas,
                             participants = participants

--- a/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/InviteMember.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/InviteMember.kt
@@ -44,7 +44,7 @@ fun SearchScreen(
                     scope.launch {
                         try {
                             val response = userApi.getUserByEmail(it)
-                            matchedEmail = response.email
+                            matchedEmail = response.data.email
                         } catch (e: HttpException) {
                             if (e.code() == 404) {
                                 matchedEmail = null

--- a/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/agenda/AgendaScreen.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/agenda/AgendaScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -40,6 +41,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.TextStyle
@@ -206,16 +208,27 @@ fun TextField(
     placeholder: @Composable (() -> Unit)? = null
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
+    val focusManager = androidx.compose.ui.platform.LocalFocusManager.current
+    val interactionSource = remember { MutableInteractionSource() }
+    var isFocused by remember { mutableStateOf(false) }
 
     OutlinedTextField(
         value = value,
         onValueChange = onValueChange,
-        modifier = modifier,
+        modifier = modifier.onFocusChanged { focusState ->
+            if (isFocused && !focusState.isFocused) {
+                onDone()
+                keyboardController?.hide()
+            }
+            isFocused = focusState.isFocused
+        },
         singleLine = true,
+        interactionSource = interactionSource,
         keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
         keyboardActions = KeyboardActions(onDone = {
             onDone()
             keyboardController?.hide()
+            focusManager.clearFocus()
         }),
         textStyle = textStyle,
         placeholder = placeholder

--- a/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/breaktime/BreakTimeScreen.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/breaktime/BreakTimeScreen.kt
@@ -24,25 +24,27 @@ fun BreakTimeRow(breakTime: MutableState<String>, breakTimeMinute: MutableState<
     fun handleBreakTimeChange(newBreakTime: String) {
         if (newBreakTime.all { it.isDigit() }) {
             breakTime.value = newBreakTime
-            if (breakTime.value.isNotEmpty() && breakTimeMinute.value.isNotEmpty()) {
+            //쉬는시간과 간격에 제한을 둘건가
+            /*if (breakTime.value.isNotEmpty() && breakTimeMinute.value.isNotEmpty()) {
                 val breakTimeInt = breakTime.value.toIntOrNull() ?: 0
                 val breakTimeMinuteInt = breakTimeMinute.value.toIntOrNull() ?: 0
                 if (breakTimeInt <= breakTimeMinuteInt) {
                     breakTimeMinute.value = "0"
                 }
-            }
+            }*/
         }
     }
 
     fun handleBreakTimeMinuteChange(newBreakTimeMinute: String) {
         if (newBreakTimeMinute.all { it.isDigit() }) {
-            val breakTimeInt = breakTime.value.toIntOrNull() ?: 0
+            breakTimeMinute.value = newBreakTimeMinute
+            /*val breakTimeInt = breakTime.value.toIntOrNull() ?: 0
             val newBreakTimeMinuteInt = newBreakTimeMinute.toIntOrNull() ?: 0
             if (breakTime.value.isNotEmpty() && newBreakTimeMinuteInt >= breakTimeInt) {
                 breakTimeMinute.value = "0"
             } else {
                 breakTimeMinute.value = newBreakTimeMinute
-            }
+            }*/
         }
     }
 

--- a/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/dateandtime/DataPickerCalendar.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/dateandtime/DataPickerCalendar.kt
@@ -1,10 +1,6 @@
 package com.imhungry.jjongseol.ui.home
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -42,7 +38,7 @@ fun DataPickerCalendar(navController: NavController, initialSelectedDate: LocalD
                     yearMonth = currentYearMonth,
                     selectedDate = selectedDate,
                     onDateSelected = { selectedDate = it },
-                    schedules = listOf()
+                    meetings = listOf()
                 )
             } else {
                 NumberPickerDialog(

--- a/app/src/main/java/com/imhungry/jjongseol/viewmodel/MeetingViewModel.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/viewmodel/MeetingViewModel.kt
@@ -1,6 +1,7 @@
 package com.imhungry.jjongseol.viewmodel
 
 import android.app.Application
+import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.imhungry.jjongseol.feature.audio.StreamingController
@@ -8,6 +9,9 @@ import com.imhungry.jjongseol.feature.audio.devtool.TestDataSender
 import com.imhungry.jjongseol.data.model.meeting.MeetingReq
 import com.imhungry.jjongseol.data.model.error.ApiError
 import com.imhungry.jjongseol.data.model.feedback.FeedbackItem
+import com.imhungry.jjongseol.data.model.home.MeetingResponse
+import com.imhungry.jjongseol.data.model.home.toMeetingInfo
+import com.imhungry.jjongseol.ui.home.meetingdata.MeetingInfo
 import com.imhungry.jjongseol.data.model.meeting.SummaryItem
 import com.imhungry.jjongseol.data.network.api.MeetingApi
 import com.imhungry.jjongseol.data.network.client.SseClient
@@ -16,6 +20,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.LocalDateTime
 import javax.inject.Inject
 
 @HiltViewModel
@@ -24,11 +30,29 @@ class MeetingViewModel @Inject constructor(
     private val sseClient: SseClient,
     private val streamingController: StreamingController,
     private val testDataSender: TestDataSender,
-    private val meetingApi: MeetingApi
+    private val meetingApi: MeetingApi,
 ) : AndroidViewModel(application) {
 
     private val _errorMessage = MutableStateFlow<String?>(null)
     val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
+
+    private val _scheduledMeetings = MutableStateFlow<List<MeetingInfo>>(emptyList())
+    val scheduledMeetings: StateFlow<List<MeetingInfo>> = _scheduledMeetings.asStateFlow()
+
+    private val _pastMeetings = MutableStateFlow<List<MeetingInfo>>(emptyList())
+    val pastMeetings: StateFlow<List<MeetingInfo>> = _pastMeetings.asStateFlow()
+
+    private val _summaryList = MutableStateFlow<List<SummaryItem>>(emptyList())
+    val summaryList: StateFlow<List<SummaryItem>> = _summaryList.asStateFlow()
+
+    private val _participationRate = MutableStateFlow<String?>(null)
+    val participationRate: StateFlow<String?> = _participationRate.asStateFlow()
+
+    private val _feedbackList = MutableStateFlow<List<FeedbackItem>>(emptyList())
+    val feedbackList: StateFlow<List<FeedbackItem>> = _feedbackList.asStateFlow()
+
+    private val _meetings = MutableStateFlow<List<MeetingResponse>>(emptyList())
+    val meetings: StateFlow<List<MeetingResponse>> = _meetings.asStateFlow()
 
     fun setError(apiError: ApiError) {
         _errorMessage.value = when (apiError.message) {
@@ -65,15 +89,6 @@ class MeetingViewModel @Inject constructor(
     fun stopStreamingService() = streamingController.stopStreamingService()
     fun pauseEncoding() = streamingController.pauseEncoding()
     fun resumeEncoding() = streamingController.resumeEncoding()
-
-    private val _summaryList = MutableStateFlow<List<SummaryItem>>(emptyList())
-    val summaryList: StateFlow<List<SummaryItem>> = _summaryList.asStateFlow()
-
-    private val _participationRate = MutableStateFlow<String?>(null)
-    val participationRate: StateFlow<String?> = _participationRate.asStateFlow()
-
-    private val _feedbackList = MutableStateFlow<List<FeedbackItem>>(emptyList())
-    val feedbackList: StateFlow<List<FeedbackItem>> = _feedbackList.asStateFlow()
 
     fun subscribeToSummary(meetingId: Long, timeProvider: () -> String) {
         sseClient.subscribeToEvent(
@@ -129,4 +144,55 @@ class MeetingViewModel @Inject constructor(
             if (!it.isRead) it.copy(isRead = true) else it
         }
     }
+
+    fun loadMeetings() {
+        viewModelScope.launch {
+            try {
+                val now = LocalDate.now()
+                val response = meetingApi.getMeetings(now.year, now.monthValue)
+
+                if (response.isSuccessful) {
+                    val meetings = response.body()?.data?.meetings ?: emptyList<MeetingResponse>()
+                    _meetings.value = meetings
+
+                    Log.d("loadMeetings", "응답 회의 수: ${meetings.size}")
+                    val meetingInfos = meetings.map { it.toMeetingInfo() }
+                    val (upcoming, past) = splitAndSortMeetings(meetingInfos)
+
+                    Log.d("loadMeetings", "예정: ${upcoming.size}, 지난: ${past.size}")
+                    _scheduledMeetings.value = upcoming
+                    _pastMeetings.value = past
+
+                } else {
+                    _errorMessage.value = "불러오기 실패: ${response.code()}"
+                    Log.e("loadMeetings", "API 실패: ${response.code()}")
+                }
+            } catch (e: Exception) {
+                _errorMessage.value = "예외 발생: ${e.message}"
+                Log.e("loadMeetings", "예외 발생: ${e.message}")
+            }
+        }
+    }
+
+    private fun splitAndSortMeetings(meetings: List<MeetingInfo>): Pair<List<MeetingInfo>, List<MeetingInfo>> {
+        val now = LocalDateTime.now()
+
+        val (upcoming, past) = meetings.partition {
+            it.startDateTime.toLocalDate() >= now.toLocalDate()
+        }
+
+        val sortedUpcoming = upcoming.sortedWith(
+            compareBy<MeetingInfo> { it.startDateTime.toLocalDate() }
+                .thenBy { it.startDateTime.toLocalTime() }
+                .thenBy { it.endDateTime.toLocalTime() }
+        )
+
+        val sortedPast = past.sortedWith(
+            compareByDescending<MeetingInfo> { it.startDateTime.toLocalDate() }
+                .thenByDescending { it.endDateTime.toLocalTime() }
+        )
+
+        return sortedUpcoming to sortedPast
+    }
+
 }

--- a/app/src/main/java/com/imhungry/jjongseol/viewmodel/ScheduleViewModel.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/viewmodel/ScheduleViewModel.kt
@@ -1,0 +1,43 @@
+package com.imhungry.jjongseol.viewmodel
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.imhungry.jjongseol.data.model.home.MeetingResponse
+import com.imhungry.jjongseol.data.network.api.MeetingApi
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import java.time.YearMonth
+import javax.inject.Inject
+import androidx.compose.runtime.*
+
+@HiltViewModel
+class ScheduleViewModel @Inject constructor(
+    private val meetingApi: MeetingApi
+) : ViewModel() {
+
+    private val _meetings = mutableStateOf<List<MeetingResponse>>(emptyList())
+    val meetings: State<List<MeetingResponse>> = _meetings
+
+    fun loadMeetings(yearMonth: YearMonth) {
+        viewModelScope.launch {
+            try {
+                val response = meetingApi.getMeetings(yearMonth.year, yearMonth.monthValue)
+
+                if (response.isSuccessful) {
+                    val meetingsData = response.body()?.data?.meetings ?: emptyList()
+                    _meetings.value = meetingsData
+                    Log.d("ScheduleViewModel", "Meetings loaded: ${meetingsData.size}건")
+                } else {
+                    Log.w(
+                        "ScheduleViewModel",
+                        "API 실패 - code: ${response.code()}, message: ${response.message()}"
+                    )
+                }
+
+            } catch (e: Exception) {
+                Log.e("ScheduleViewModel", "네트워크 예외 발생: ${e.localizedMessage}", e)
+            }
+        }
+    }
+}


### PR DESCRIPTION
feat: 회의 생성 페이지 완료 및 홈 화면, 캘린더에 회의 정보 추가

- 회의 생성 페이지에 참여자 추가 기능 수정

- 예정된 회의, 지난 회의에 일정 뜨고
- 캘린더에 색상에 맞춰서 회의 일정 뜸 (색상은 임시)
