### PR TITLE
feat: 조회 및 수정 페이지 수정

### DIFF
--- a/app/src/main/java/com/imhungry/jjongseol/data/model/meeting/request/ParticipantAddReq.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/data/model/meeting/request/ParticipantAddReq.kt
@@ -1,0 +1,5 @@
+package com.imhungry.jjongseol.data.model.meeting.request
+
+data class ParticipantAddReq(
+    val emails: List<String>
+)

--- a/app/src/main/java/com/imhungry/jjongseol/data/model/user/UserResponse.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/data/model/user/UserResponse.kt
@@ -1,7 +1,6 @@
 package com.imhungry.jjongseol.data.model.user
 
-data class UserDto(
-    val userId: Long,
+data class UserResponse(
     val message: String,
     val data: UserData
 )

--- a/app/src/main/java/com/imhungry/jjongseol/data/network/api/MeetingUserApi.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/data/network/api/MeetingUserApi.kt
@@ -1,0 +1,22 @@
+package com.imhungry.jjongseol.data.network.api
+
+import com.imhungry.jjongseol.data.model.meeting.request.ParticipantAddReq
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+interface MeetingUserApi {
+    @POST("/api/meeting-users/{meetingId}")
+    suspend fun addParticipants(
+        @Path("meetingId") meetingId: Long,
+        @Body request: ParticipantAddReq
+    ): Response<Unit>
+
+    @DELETE("/api/meeting-users/{meetingId}/{participantUserId}")
+    suspend fun removeParticipant(
+        @Path("meetingId") meetingId: Long,
+        @Path("participantUserId") participantUserId: Long
+    ): Response<Unit>
+}

--- a/app/src/main/java/com/imhungry/jjongseol/data/network/config/RetrofitModule.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/data/network/config/RetrofitModule.kt
@@ -4,9 +4,11 @@ import com.imhungry.jjongseol.BuildConfig
 import com.imhungry.jjongseol.data.network.api.AgendaApi
 import com.imhungry.jjongseol.data.network.api.AudioApi
 import com.imhungry.jjongseol.data.network.api.MeetingApi
+import com.imhungry.jjongseol.data.network.api.MeetingUserApi
 import com.imhungry.jjongseol.data.network.api.UserApi
 import dagger.Module
 import dagger.Provides
+import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
@@ -61,4 +63,17 @@ object RetrofitModule {
     fun provideAudioApi(retrofit: Retrofit): AudioApi {
         return retrofit.create(AudioApi::class.java)
     }
+
+    @Provides
+    @Singleton
+    fun provideMeetingUserApi(retrofit: Retrofit): MeetingUserApi {
+        return retrofit.create(MeetingUserApi::class.java)
+    }
+
+    @EntryPoint
+    @InstallIn(SingletonComponent::class)
+    interface MeetingUserApiEntryPoint {
+        fun meetingUserApi(): MeetingUserApi
+    }
+
 }

--- a/app/src/main/java/com/imhungry/jjongseol/data/repository/MeetingUserRepository.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/data/repository/MeetingUserRepository.kt
@@ -1,0 +1,19 @@
+package com.imhungry.jjongseol.data.repository
+
+import com.imhungry.jjongseol.data.model.meeting.request.ParticipantAddReq
+import com.imhungry.jjongseol.data.network.api.MeetingUserApi
+import javax.inject.Inject
+
+class MeetingUserRepository @Inject constructor(
+    private val api: MeetingUserApi
+) {
+    suspend fun addParticipants(meetingId: Long, emails: List<String>): Boolean {
+        val response = api.addParticipants(meetingId, ParticipantAddReq(emails))
+        return response.isSuccessful
+    }
+
+    suspend fun removeParticipant(meetingId: Long, participantUserId: Long): Boolean {
+        val response = api.removeParticipant(meetingId, participantUserId)
+        return response.isSuccessful
+    }
+}

--- a/app/src/main/java/com/imhungry/jjongseol/ui/learningvoice/RecordingVoiceScreen.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/learningvoice/RecordingVoiceScreen.kt
@@ -1,6 +1,9 @@
 package com.imhungry.jjongseol.ui.learningvoice
 import android.content.Context
 import android.media.MediaRecorder
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -28,6 +31,7 @@ import com.imhungry.jjongseol.ui.theme.blackColor
 import com.imhungry.jjongseol.ui.theme.danger
 import com.imhungry.jjongseol.viewmodel.AudioViewModel
 import java.io.File
+import android.Manifest
 
 @Composable
 fun RecordingVoiceScreen(
@@ -36,6 +40,28 @@ fun RecordingVoiceScreen(
 ) {
     val context = LocalContext.current
     val isVoiceTutorialCompleted = remember { AppPrefs(context).isVoiceTutorialCompleted() }
+
+    var permissionGranted by remember { mutableStateOf(false) }
+    var permissionRequested by remember { mutableStateOf(false) }
+
+    val requiredPermissions = remember {
+        buildList {
+            add(Manifest.permission.RECORD_AUDIO)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                add(Manifest.permission.POST_NOTIFICATIONS)
+            }
+        }
+    }
+
+    val launcher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { perms ->
+        permissionGranted = requiredPermissions.all {
+            perms[it] == true
+        }
+        permissionRequested = true
+    }
+
 
     LaunchedEffect(isVoiceTutorialCompleted) {
         if (isVoiceTutorialCompleted) {

--- a/app/src/main/java/com/imhungry/jjongseol/ui/meetingdetail/MeetingDetailEditScreen.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/meetingdetail/MeetingDetailEditScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import com.imhungry.jjongseol.ui.component.dialog.CustomDialog
 import com.imhungry.jjongseol.viewmodel.AgendaViewModel
 import com.imhungry.jjongseol.viewmodel.MeetingViewModel
 import java.time.LocalDateTime
@@ -176,36 +177,28 @@ fun MeetingDetailEditScreen(
     )
 
     if (showCancelDialog.value) {
-        AlertDialog(
+        CustomDialog(
+            description = "수정한 내용이 모두 사라집니다. 정말 취소하시겠습니까?",
+            confirmText = "확인",
+            dismissText = "취소",
             onDismissRequest = { showCancelDialog.value = false },
-            title = { Text("수정 취소") },
-            text = { Text("수정한 내용이 모두 사라집니다. 정말 취소하시겠습니까?") },
-            confirmButton = {
-                TextButton(onClick = {
-                    title.value = originalTitle.value
-                    location.value = originalLocation.value
-                    date.value = originalDate.value
-                    startTime.value = originalStartTime.value
-                    endTime.value = originalEndTime.value
-                    totalTime.value = originalTotalTime.value
-                    restInterval.value = originalRestInterval.value
-                    restDuration.value = originalRestDuration.value
+            onConfirmExit = {
+                title.value = originalTitle.value
+                location.value = originalLocation.value
+                date.value = originalDate.value
+                startTime.value = originalStartTime.value
+                endTime.value = originalEndTime.value
+                totalTime.value = originalTotalTime.value
+                restInterval.value = originalRestInterval.value
+                restDuration.value = originalRestDuration.value
 
-                    agendaViewModel.restoreAgendas(originalAgendas.toList())
+                agendaViewModel.restoreAgendas(originalAgendas.toList())
 
-                    participants.clear()
-                    participants.addAll(originalParticipants)
+                participants.clear()
+                participants.addAll(originalParticipants)
 
-                    isEditable.value = false
-                    showCancelDialog.value = false
-                }) {
-                    Text("확인")
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { showCancelDialog.value = false }) {
-                    Text("취소")
-                }
+                isEditable.value = false
+                showCancelDialog.value = false
             }
         )
     }

--- a/app/src/main/java/com/imhungry/jjongseol/ui/meetingdetail/MeetingDetailScreen.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/meetingdetail/MeetingDetailScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -24,6 +25,8 @@ import androidx.constraintlayout.compose.Dimension
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.imhungry.jjongseol.data.model.meeting.MeetingStatus
+import com.imhungry.jjongseol.data.network.api.MeetingUserApi
+import com.imhungry.jjongseol.data.network.config.RetrofitModule
 import com.imhungry.jjongseol.ui.home.DataPickerCalendar
 import com.imhungry.jjongseol.ui.newmeeting.CustomBackButton
 import com.imhungry.jjongseol.ui.newmeeting.agenda.AgendaListScreen
@@ -36,7 +39,9 @@ import com.imhungry.jjongseol.ui.theme.UserGray
 import com.imhungry.jjongseol.ui.theme.UserGreen1
 import com.imhungry.jjongseol.ui.theme.UserGreen2
 import com.imhungry.jjongseol.viewmodel.AgendaViewModel
+import com.imhungry.jjongseol.viewmodel.MeetingViewModel
 import com.imhungry.jjongseol.viewmodel.UserViewModel
+import dagger.hilt.android.EntryPointAccessors
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -64,6 +69,17 @@ fun MeetingDetailScreen(
 
     val agendaViewModel: AgendaViewModel = hiltViewModel()
     val agendaItems by agendaViewModel.agendaItems.collectAsState()
+
+    val userViewModel: UserViewModel = hiltViewModel()
+    val context = LocalContext.current
+    val meetingUserApi = remember {
+        EntryPointAccessors.fromApplication(
+            context.applicationContext,
+            RetrofitModule.MeetingUserApiEntryPoint::class.java
+        ).meetingUserApi()
+    }
+
+    val selectedEmails = remember { mutableStateOf(participants) }
 
     LaunchedEffect(id) {
         agendaViewModel.loadAgendas(id)
@@ -172,8 +188,10 @@ fun MeetingDetailScreen(
 
                     Column(modifier = Modifier.weight(5f)) {
                         SearchScreen(
-                            selectedEmails = remember { mutableStateOf(participants) },
-                            userApi = hiltViewModel<UserViewModel>().userApi,
+                            meetingId = id,
+                            selectedEmails = selectedEmails,
+                            userApi = userViewModel.userApi,
+                            meetingUserApi = meetingUserApi,
                             enabled = isEditable
                         )
 

--- a/app/src/main/java/com/imhungry/jjongseol/ui/meetingdetail/MeetingDetailScreen.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/meetingdetail/MeetingDetailScreen.kt
@@ -399,13 +399,21 @@ fun MeetingDetailScreen(
 
             }
 
-            item{
-                Row(modifier = Modifier
+            item {
+                Row(
+                    modifier = Modifier
                         .padding(top = 15.dp, bottom = 10.dp)
                         .fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(10.dp)
                 ) {
-                    if (isEditable) {
+                    val meetingStatus = try {
+                        MeetingStatus.valueOf(status.value)
+                    } catch (e: IllegalArgumentException) {
+                        null
+                    }
+
+                    if (isHost && meetingStatus == MeetingStatus.WAITING) {
+                        //호스트이면서 회의 상태가 WAITING일 경우
                         Button(
                             modifier = Modifier
                                 .weight(1f)
@@ -415,7 +423,7 @@ fun MeetingDetailScreen(
                                 backgroundColor = UserGray,
                                 contentColor = Color.Black
                             ),
-                            onClick = { onEditClicked() }
+                            onClick = { navController.popBackStack() }
                         ) {
                             Text("취소", style = TextStyle(fontWeight = FontWeight.Bold, fontSize = 15.sp))
                         }
@@ -429,30 +437,33 @@ fun MeetingDetailScreen(
                                 backgroundColor = UserGreen1,
                                 contentColor = Color.White
                             ),
-                            onClick = { onConfirmEditClicked() }
-                        ) {
-                            Text("확인", style = TextStyle(fontWeight = FontWeight.Bold, fontSize = 15.sp))
-                        }
-                    } else {
-                        if (isHost) {
-                            Button(
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .height(50.dp)
-                                    .border(1.dp, UserGray, RoundedCornerShape(15.dp)),
-                                colors = ButtonDefaults.buttonColors(
-                                    backgroundColor = UserGray,
-                                    contentColor = Color.Black
-                                ),
-                                onClick = { navController.popBackStack() }
-                            ) {
-                                Text("취소", style = TextStyle(fontWeight = FontWeight.Bold, fontSize = 15.sp))
+                            onClick = {
+                                navController.navigate("meetingRoute/inprogress/$id")
                             }
+                        ) {
+                            Text("입장", style = TextStyle(fontWeight = FontWeight.Bold, fontSize = 15.sp))
                         }
 
                         Button(
                             modifier = Modifier
-                                .weight(if (isHost) 1f else 1.5f)
+                                .weight(1f)
+                                .height(50.dp)
+                                .border(1.dp, UserGreen2, RoundedCornerShape(15.dp)),
+                            colors = ButtonDefaults.buttonColors(
+                                backgroundColor = UserGreen2,
+                                contentColor = Color.Black
+                            ),
+                            onClick = onEditClicked
+                        ) {
+                            Text("수정", style = TextStyle(fontWeight = FontWeight.Bold, fontSize = 15.sp))
+                        }
+                    } else {
+                        //호스트가 아니거나 WAITING이 아닌 경우
+                        val buttonText = if (meetingStatus == MeetingStatus.COMPLETED) "회의록 조회" else "입장"
+
+                        Button(
+                            modifier = Modifier
+                                .fillMaxWidth()
                                 .height(50.dp)
                                 .border(1.dp, UserGreen1, RoundedCornerShape(15.dp)),
                             colors = ButtonDefaults.buttonColors(
@@ -460,7 +471,7 @@ fun MeetingDetailScreen(
                                 contentColor = Color.White
                             ),
                             onClick = {
-                                when (MeetingStatus.valueOf(status.value)) {
+                                when (meetingStatus) {
                                     MeetingStatus.WAITING -> navController.navigate("meetingRoute/waiting/$id")
                                     MeetingStatus.IN_PROGRESS -> navController.navigate("meetingRoute/inprogress/$id")
                                     MeetingStatus.COMPLETED -> navController.navigate("meetingRoute/completed/$id")
@@ -468,23 +479,7 @@ fun MeetingDetailScreen(
                                 }
                             }
                         ) {
-                            Text("입장", style = TextStyle(fontWeight = FontWeight.Bold, fontSize = 15.sp))
-                        }
-
-                        if (isHost) {
-                            Button(
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .height(50.dp)
-                                    .border(1.dp, UserGreen2, RoundedCornerShape(15.dp)),
-                                colors = ButtonDefaults.buttonColors(
-                                    backgroundColor = UserGreen2,
-                                    contentColor = Color.Black
-                                ),
-                                onClick = onEditClicked
-                            ) {
-                                Text("수정", style = TextStyle(fontWeight = FontWeight.Bold, fontSize = 15.sp))
-                            }
+                            Text(buttonText, style = TextStyle(fontWeight = FontWeight.Bold, fontSize = 15.sp))
                         }
                     }
                 }

--- a/app/src/main/java/com/imhungry/jjongseol/ui/meetingdetail/MeetingDetailScreen.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/meetingdetail/MeetingDetailScreen.kt
@@ -81,8 +81,15 @@ fun MeetingDetailScreen(
 
     val selectedEmails = remember { mutableStateOf(participants) }
 
+    val userInfo by userViewModel.userInfo.collectAsState()
+    val myEmail = userInfo?.email.orEmpty()
+
     LaunchedEffect(id) {
         agendaViewModel.loadAgendas(id)
+    }
+
+    LaunchedEffect(Unit) {
+        userViewModel.loadMyProfile()
     }
 
     ConstraintLayout(
@@ -192,7 +199,8 @@ fun MeetingDetailScreen(
                             selectedEmails = selectedEmails,
                             userApi = userViewModel.userApi,
                             meetingUserApi = meetingUserApi,
-                            enabled = isEditable
+                            enabled = isEditable,
+                            hostEmail = myEmail
                         )
 
                     }

--- a/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/CompletedNewMeeting.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/CompletedNewMeeting.kt
@@ -1,6 +1,5 @@
 package com.imhungry.jjongseol.ui.newmeeting
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -8,13 +7,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
@@ -23,104 +20,101 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.constraintlayout.compose.ConstraintLayout
-import androidx.constraintlayout.compose.Dimension
 import androidx.navigation.NavController
+import coil.compose.rememberAsyncImagePainter
+import coil.decode.GifDecoder
+import coil.request.ImageRequest
 import com.imhungry.jjongseol.R
+import com.imhungry.jjongseol.ui.theme.SetNavigationBarColor
 import com.imhungry.jjongseol.ui.theme.md_theme_button_color_blue
+import androidx.compose.foundation.layout.*
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.text.font.FontWeight
+import com.imhungry.jjongseol.ui.theme.UserGreen1
+
 
 @Composable
 fun CompletedNewMeeting(navController: NavController) {
-    ConstraintLayout(
+    SetNavigationBarColor(Color.White)
+
+    Box(
         modifier = Modifier
-            .background(Color.White)
             .fillMaxSize()
+            .background(Color.White)
+            .navigationBarsPadding()
     ) {
-
-        val scrollList = createRef()
-
-        LazyColumn(
+        Column(
             modifier = Modifier
-                .padding(30.dp)
-                .fillMaxSize()
-                .constrainAs(scrollList) {
-                    top.linkTo(parent.top)
-                    bottom.linkTo(parent.bottom)
-                    end.linkTo(parent.end)
-                    start.linkTo(parent.start)
-                    height = Dimension.fillToConstraints
-                },
+                .fillMaxWidth()
+                .padding(top = 130.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            item{
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(80.dp)
-                        .padding(top = 10.dp, bottom = 20.dp),
-                    contentAlignment = Alignment.Center
-                ){
-                    Text("회의 생성",
-                        style = TextStyle(
-                            color = Color.Gray,
-                            fontSize = 30.sp,
-                        )
-                    )
-                }
-            }
+            Image(
+                painter = rememberAsyncImagePainter(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(R.drawable.gif)
+                        .decoderFactory(GifDecoder.Factory())
+                        .build()
+                ),
+                contentDescription = "회의 생성 완료 gif",
+                modifier = Modifier
+                    .size(200.dp)
+                    .fillMaxWidth()
+            )
 
-            item {
-                Box( contentAlignment = Alignment.Center) {
-                    Image(
-                        painter = painterResource(id = R.drawable.newmeeting_completed),
-                        contentDescription = "회의 생성 완료",
-                        modifier = Modifier
-                            .height(300.dp)
-                            .width(300.dp)
-                    )
-                }
-            }
+            Spacer(modifier = Modifier.height(10.dp))
 
-            item{
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(80.dp)
-                        .padding(top = 10.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        "성공적으로 생성되었어요!~",
-                        style = TextStyle(
-                            color = Color.Gray,
-                            fontSize = 30.sp,
-                        )
+            Text(
+                text = "회의 생성 완료",
+                color = Color.Black,
+                fontSize = 30.sp,
+                fontWeight = FontWeight.Bold
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Text(
+                text = "회의 일정이 성공적으로 생성되었습니다.!",
+                color = Color.Black,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Bold
+            )
+
+        }
+
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 20.dp, vertical = 40.dp),
+            verticalArrangement = Arrangement.Bottom,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Button(
+                onClick = { navController.navigate("home") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(55.dp)
+                    .border(1.dp, UserGreen1, RoundedCornerShape(13.dp)),
+                shape = RoundedCornerShape(13.dp),
+                colors = ButtonDefaults.buttonColors(
+                    backgroundColor = UserGreen1,
+                    contentColor = Color.White
+                ),
+                elevation = null
+            ) {
+                Text(
+                    "완료",
+                    style = TextStyle(
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White
                     )
-                }
-            }
-            item{
-                Column(verticalArrangement = Arrangement.Center){
-                    Button(modifier = Modifier.fillMaxWidth()
-                        .padding(start = 8.dp, end = 8.dp, top = 15.dp, bottom = 8.dp)
-                        .height(60.dp)
-                        .border(BorderStroke(0.dp, Color.Transparent)),
-                        colors = ButtonDefaults.buttonColors(
-                            backgroundColor = Color.Transparent,
-                            contentColor = Color.Black
-                        ),
-                        elevation = null,
-                        onClick = {
-                            navController.navigate("home")
-                        }) {
-                        Text(
-                            "홈으로 가기",
-                            style = TextStyle(color = md_theme_button_color_blue, fontSize = 25.sp)
-                        )
-                    }
-                }
+                )
             }
         }
     }

--- a/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/CreateNewMeeting.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/CreateNewMeeting.kt
@@ -44,7 +44,10 @@ import androidx.constraintlayout.compose.Dimension
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import android.util.Log
+import androidx.compose.ui.platform.LocalContext
 import com.imhungry.jjongseol.data.model.meeting.MeetingReq
+import com.imhungry.jjongseol.data.network.api.MeetingUserApi
+import com.imhungry.jjongseol.data.network.config.RetrofitModule
 import com.imhungry.jjongseol.ui.home.DataPickerCalendar
 import com.imhungry.jjongseol.ui.newmeeting.agenda.AgendaListScreen
 import com.imhungry.jjongseol.ui.newmeeting.breaktime.BreakTimeRow
@@ -54,6 +57,7 @@ import com.imhungry.jjongseol.ui.theme.Purple1
 import com.imhungry.jjongseol.ui.theme.UserGreen1
 import com.imhungry.jjongseol.viewmodel.MeetingViewModel
 import com.imhungry.jjongseol.viewmodel.UserViewModel
+import dagger.hilt.android.EntryPointAccessors
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -62,6 +66,14 @@ import java.time.format.DateTimeFormatter
 fun CreateNewMeetingScreen(navController: NavController){
     val meetingViewModel: MeetingViewModel = hiltViewModel()
     val userViewModel: UserViewModel = hiltViewModel()
+
+    val context = LocalContext.current
+    val meetingUserApi = remember {
+        EntryPointAccessors.fromApplication(
+            context.applicationContext,
+            RetrofitModule.MeetingUserApiEntryPoint::class.java
+        ).meetingUserApi()
+    }
 
     val meetingTitle = remember { mutableStateOf("") }
 
@@ -87,7 +99,6 @@ fun CreateNewMeetingScreen(navController: NavController){
     val isPlaceError = remember { mutableStateOf(false) }
     val isAgendaError = remember { mutableStateOf(false) }
     val isBreakTimeError = remember { mutableStateOf(false) }
-
     ConstraintLayout (modifier = Modifier
         .background(Color.White)
         .fillMaxSize()){
@@ -186,8 +197,10 @@ fun CreateNewMeetingScreen(navController: NavController){
 
                     Column(modifier = Modifier.weight(5f)) {
                         SearchScreen(
+                            meetingId = -1L,
                             selectedEmails = selectedMembers,
                             userApi = userViewModel.userApi,
+                            meetingUserApi = meetingUserApi,
                             enabled = true
                         )
                     }

--- a/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/CreateNewMeeting.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/CreateNewMeeting.kt
@@ -44,6 +44,7 @@ import androidx.constraintlayout.compose.Dimension
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import android.util.Log
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.platform.LocalContext
 import com.imhungry.jjongseol.data.model.meeting.MeetingReq
 import com.imhungry.jjongseol.data.network.api.MeetingUserApi
@@ -99,6 +100,12 @@ fun CreateNewMeetingScreen(navController: NavController){
     val isPlaceError = remember { mutableStateOf(false) }
     val isAgendaError = remember { mutableStateOf(false) }
     val isBreakTimeError = remember { mutableStateOf(false) }
+
+    val isHost by meetingViewModel.isHost.collectAsState()
+
+    val userInfo by userViewModel.userInfo.collectAsState()
+    val myEmail = userInfo?.email.orEmpty()
+
     ConstraintLayout (modifier = Modifier
         .background(Color.White)
         .fillMaxSize()){
@@ -201,7 +208,8 @@ fun CreateNewMeetingScreen(navController: NavController){
                             selectedEmails = selectedMembers,
                             userApi = userViewModel.userApi,
                             meetingUserApi = meetingUserApi,
-                            enabled = true
+                            enabled = true,
+                            hostEmail = myEmail
                         )
                     }
                 }

--- a/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/InviteMember.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/InviteMember.kt
@@ -33,6 +33,7 @@ import com.imhungry.jjongseol.ui.theme.md_theme_button_color_blue
 import com.imhungry.jjongseol.data.network.api.UserApi
 import com.imhungry.jjongseol.ui.theme.BasicBackGround
 import com.imhungry.jjongseol.ui.theme.UserGray
+import com.imhungry.jjongseol.ui.theme.UserGreen2
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
 
@@ -42,7 +43,8 @@ fun SearchScreen(
     selectedEmails: MutableState<List<String>>,
     userApi: UserApi,
     meetingUserApi: MeetingUserApi,
-    enabled: Boolean
+    enabled: Boolean,
+    hostEmail: String
 ) {
     var query by remember { mutableStateOf("") }
     var matchedEmail by remember { mutableStateOf<String?>(null) }
@@ -170,7 +172,7 @@ fun SearchScreen(
             verticalArrangement = Arrangement.spacedBy(2.dp)
         ) {
             selectedEmails.value.forEach { email ->
-                Chip(email, enabled = enabled, onRemove = {
+                Chip(email, enabled = enabled, isHostParticipant = email == hostEmail, onRemove = {
                     scope.launch {
                         try {
                             val userDto = userApi.getUserByEmail(email)
@@ -183,7 +185,7 @@ fun SearchScreen(
                                 errorMessage = "삭제 실패: 사용자 ID를 찾을 수 없습니다."
                             }
                         } catch (e: Exception) {
-                            errorMessage = "참가자 삭제 실패: ${e.message}"
+                            Log.d("SearchScreen","참가자 삭제 실패: ${e.message}")
                         }
                     }
                 })
@@ -194,35 +196,43 @@ fun SearchScreen(
 }
 
 @Composable
-fun Chip(text: String, enabled: Boolean, onRemove: () -> Unit) {
+fun Chip(
+    text: String,
+    enabled: Boolean,
+    isHostParticipant: Boolean,
+    onRemove: () -> Unit
+) {
+    val canRemove = enabled && !isHostParticipant
+    val chipColor = if (isHostParticipant) UserGreen2 else BasicBackGround
+
     Surface(
         modifier = Modifier
             .padding(4.dp)
-            .then(if (enabled) Modifier.clickable { onRemove() } else Modifier),
-        color = BasicBackGround,
+            .then(if (canRemove) Modifier.clickable { onRemove() } else Modifier),
+        color = chipColor,
         shape = RoundedCornerShape(20)
     ) {
-        CustomStyledText(text, enabled)
+        CustomStyledText(text = text, showX = canRemove)
     }
 }
 
-
 @Composable
-fun CustomStyledText(text: String, enabled: Boolean) {
+fun CustomStyledText(text: String, showX: Boolean) {
     val annotatedString = buildAnnotatedString {
         withStyle(style = SpanStyle(color = Color.Black, fontSize = 12.sp)) {
             append(text)
         }
-        withStyle(
-            style = SpanStyle(
-                color = Color.DarkGray,
-                fontSize = 12.sp,
-                fontWeight = FontWeight.Bold
-            )
-        ) {
-            append(" X")
+        if (showX) {
+            withStyle(
+                style = SpanStyle(
+                    color = Color.DarkGray,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Bold
+                )
+            ) {
+                append(" X")
+            }
         }
-
     }
 
     Text(

--- a/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/InviteMember.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/ui/newmeeting/InviteMember.kt
@@ -1,5 +1,6 @@
 package com.imhungry.jjongseol.ui.newmeeting.invite
 
+import android.util.Log
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
@@ -26,6 +27,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.imhungry.jjongseol.data.model.meeting.request.ParticipantAddReq
+import com.imhungry.jjongseol.data.network.api.MeetingUserApi
 import com.imhungry.jjongseol.ui.theme.md_theme_button_color_blue
 import com.imhungry.jjongseol.data.network.api.UserApi
 import com.imhungry.jjongseol.ui.theme.BasicBackGround
@@ -35,8 +38,10 @@ import retrofit2.HttpException
 
 @Composable
 fun SearchScreen(
+    meetingId: Long,
     selectedEmails: MutableState<List<String>>,
     userApi: UserApi,
+    meetingUserApi: MeetingUserApi,
     enabled: Boolean
 ) {
     var query by remember { mutableStateOf("") }
@@ -122,23 +127,33 @@ fun SearchScreen(
             )
         }
 
-        if (matchedEmail != null && !selectedEmails.value.contains(matchedEmail)) {
+        val emailToAdd = matchedEmail
+        if (!emailToAdd.isNullOrBlank() && !selectedEmails.value.contains(emailToAdd)) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 10.dp, vertical = 5.dp)
                     .border(0.5.dp, Color.Gray, RoundedCornerShape(10.dp))
-                    .then(
-                        if (enabled) Modifier.clickable {
-                            selectedEmails.value = selectedEmails.value + matchedEmail!!
-                            query = ""
-                            matchedEmail = null
-                            errorMessage = null
-                        } else Modifier
-                    )
+                    .then(if (enabled) Modifier.clickable {
+                        scope.launch {
+                            try {
+                                meetingUserApi.addParticipants(
+                                    meetingId,
+                                    ParticipantAddReq(listOf(emailToAdd))
+                                )
+                                selectedEmails.value = selectedEmails.value + emailToAdd
+                                query = ""
+                                matchedEmail = null
+                                errorMessage = null
+                            } catch (e: HttpException) {
+                                val errorBody = e.response()?.errorBody()?.string()
+                                errorMessage = "참가자 추가 실패: ${e.code()} ${e.message()} \n$errorBody"
+                            }
+                        }
+                    } else Modifier)
             ) {
                 Text(
-                    text = matchedEmail!!,
+                    text = emailToAdd,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(8.dp),
@@ -156,9 +171,24 @@ fun SearchScreen(
         ) {
             selectedEmails.value.forEach { email ->
                 Chip(email, enabled = enabled, onRemove = {
-                    selectedEmails.value = selectedEmails.value - email
+                    scope.launch {
+                        try {
+                            val userDto = userApi.getUserByEmail(email)
+                            val userId = userDto.userId
+                            Log.d("SearchScreen", "삭제 요청: meetingId=$meetingId, email=$email, userId=$userId")
+                            if (userId != null) {
+                                meetingUserApi.removeParticipant(meetingId, userId)
+                                selectedEmails.value = selectedEmails.value - email
+                            } else {
+                                errorMessage = "삭제 실패: 사용자 ID를 찾을 수 없습니다."
+                            }
+                        } catch (e: Exception) {
+                            errorMessage = "참가자 삭제 실패: ${e.message}"
+                        }
+                    }
                 })
             }
+
         }
     }
 }

--- a/app/src/main/java/com/imhungry/jjongseol/viewmodel/MeetingViewModel.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/viewmodel/MeetingViewModel.kt
@@ -123,6 +123,9 @@ class MeetingViewModel @Inject constructor(
     private val _meetingNoteStatus = MutableStateFlow<Pair<Boolean, Boolean>>(false to false) // (created, completed)
     val meetingNoteStatus: StateFlow<Pair<Boolean, Boolean>> = _meetingNoteStatus
 
+    private val _isHost = MutableStateFlow(false)
+    val isHost: StateFlow<Boolean> = _isHost
+
     fun onNewdiarizedSegments(msg: DiarizedSegment) {
         _diarizedSegments.update { oldList ->
             val mutable = oldList.toMutableList()
@@ -260,6 +263,7 @@ class MeetingViewModel @Inject constructor(
                 is MeetingResult.Success -> {
                     _meetingDetail.value = result.data
                     _meetingStatus.value = MeetingStatus.from(result.data.meetingStatus)
+                    _isHost.value = result.data.isHost
                     // 참가자 이메일로 userInfo 로딩 시작
                     val emails = result.data.participants.map { it.email }
                     // 병렬 요청

--- a/app/src/main/java/com/imhungry/jjongseol/viewmodel/MeetingViewModel.kt
+++ b/app/src/main/java/com/imhungry/jjongseol/viewmodel/MeetingViewModel.kt
@@ -31,6 +31,7 @@ import com.imhungry.jjongseol.data.repository.MeetingNoteEventBus
 import com.imhungry.jjongseol.data.repository.MeetingRepository
 import com.imhungry.jjongseol.data.repository.MeetingResult
 import com.imhungry.jjongseol.data.repository.MeetingStartTimeEventBus
+import com.imhungry.jjongseol.data.repository.MeetingUserRepository
 import com.imhungry.jjongseol.data.repository.ParticipationRateRepository
 import com.imhungry.jjongseol.data.repository.SummaryRepository
 import com.imhungry.jjongseol.data.repository.UserRepository
@@ -56,6 +57,7 @@ class MeetingViewModel @Inject constructor(
     private val agendaApi: AgendaApi,
     private val feedbackRepository: FeedbackRepository,
     private val summaryRepository: SummaryRepository,
+    private val meetingUserRepository: MeetingUserRepository,
 ) : ViewModel() {
 
     private val _meetingDetail = MutableStateFlow<MeetingDetailRes?>(null)
@@ -505,6 +507,20 @@ class MeetingViewModel @Inject constructor(
 
     fun addFeedback(feedback: FeedbackDto) {
         _feedbackList.update { old -> old + feedback }
+    }
+
+    fun addParticipants(meetingId: Long, emails: List<String>, onSuccess: () -> Unit, onError: (String) -> Unit) {
+        viewModelScope.launch {
+            val result = meetingUserRepository.addParticipants(meetingId, emails)
+            if (result) onSuccess() else onError("참가자 추가 실패")
+        }
+    }
+
+    fun removeParticipant(meetingId: Long, participantUserId: Long, onSuccess: () -> Unit, onError: (String) -> Unit) {
+        viewModelScope.launch {
+            val result = meetingUserRepository.removeParticipant(meetingId, participantUserId)
+            if (result) onSuccess() else onError("참가자 삭제 실패")
+        }
     }
 
 }


### PR DESCRIPTION
- 회의 조회 기능( 참석자 - 추가 가능 )
- 수정 화면에서 리더는 삭제 불가 및 리더는 따로 표시
- 리더면서, 회의 상태가 WAITING 일 경우에만 수정 가능
     - 그게 아니라면 입장, 혹은 회의록 조회 버튼
     - 회의록 조회 <- 회의 상태가 COMPLETED 일때

기타
- 목소리 학습 화면에서 마이크 권한 추가
- 회의 완료 페이지 ui 변경
- 팝업 디자인 변경